### PR TITLE
Fix JWT secret injection

### DIFF
--- a/src/main/java/com/myslotify/slotify/service/JwtServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/JwtServiceImpl.java
@@ -17,8 +17,11 @@ import java.util.Date;
 @Service
 public class JwtServiceImpl implements JwtService {
 
-    @Value("${app.jwt.secret}")
-    private static String SECRET_KEY;
+    private final String secretKey;
+
+    public JwtServiceImpl(@Value("${app.jwt.secret}") String secretKey) {
+        this.secretKey = secretKey;
+    }
 
     public String generateToken(User user) {
         return Jwts.builder()
@@ -31,7 +34,7 @@ public class JwtServiceImpl implements JwtService {
     }
 
     private Key getKey() {
-        return Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+        return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     }
 
     public String extractEmail(String token) {


### PR DESCRIPTION
## Summary
- inject `app.jwt.secret` via constructor in `JwtServiceImpl`
- use the injected secret when creating keys

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68432595abc0832c9b20687a2048365c