### PR TITLE
Fix tenant activation logic

### DIFF
--- a/src/main/java/com/myslotify/slotify/repository/TenantRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/TenantRepository.java
@@ -4,8 +4,10 @@ import com.myslotify.slotify.entity.Tenant;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface TenantRepository extends JpaRepository<Tenant, UUID> {
+    Optional<Tenant> findByName(String name);
 }

--- a/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
@@ -45,7 +45,8 @@ public class TenantServiceImpl implements TenantService {
 
     @Transactional
     public Tenant activateTenant(String name, String schemaName) {
-        Tenant tenant = new Tenant();
+        Tenant tenant = tenantRepository.findByName(name)
+                .orElseThrow(() -> new RuntimeException("Tenant not found"));
         tenant.setSubscriptionStatus(SubscriptionStatus.ACTIVE);
 
         tenantRepository.save(tenant);


### PR DESCRIPTION
## Summary
- update `activateTenant` so it loads existing tenant and activates it
- add repository method `findByName`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684325943754832cab6f2e581a7f301e