### PR TITLE
Remove service annotations from interfaces

### DIFF
--- a/src/main/java/com/myslotify/slotify/service/AuthService.java
+++ b/src/main/java/com/myslotify/slotify/service/AuthService.java
@@ -3,9 +3,7 @@ package com.myslotify.slotify.service;
 import com.myslotify.slotify.dto.AuthResponse;
 import com.myslotify.slotify.dto.LoginRequest;
 import com.myslotify.slotify.dto.ResetPasswordRequest;
-import org.springframework.stereotype.Service;
 
-@Service
 public interface AuthService {
     AuthResponse login(LoginRequest request);
     AuthResponse resetPassword(ResetPasswordRequest request);

--- a/src/main/java/com/myslotify/slotify/service/JwtService.java
+++ b/src/main/java/com/myslotify/slotify/service/JwtService.java
@@ -1,11 +1,7 @@
 package com.myslotify.slotify.service;
 
 import com.myslotify.slotify.entity.User;
-import org.springframework.stereotype.Service;
 
-import java.security.Key;
-
-@Service
 public interface JwtService {
 
     String generateToken(User user);


### PR DESCRIPTION
## Summary
- clean up JwtService and AuthService interfaces
- remove unused `Key` import

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68432c6cb524832c88c81b3b3e229a27