### PR TITLE
Add shared BaseAccount

### DIFF
--- a/src/main/java/com/myslotify/slotify/dto/AuthResponse.java
+++ b/src/main/java/com/myslotify/slotify/dto/AuthResponse.java
@@ -1,6 +1,6 @@
 package com.myslotify.slotify.dto;
 
-import com.myslotify.slotify.entity.User;
+import com.myslotify.slotify.entity.BaseAccount;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -9,5 +9,5 @@ import lombok.Data;
 public class AuthResponse {
     public String message;
     public String token;
-    public User user;
+    public BaseAccount account;
 }

--- a/src/main/java/com/myslotify/slotify/entity/Admin.java
+++ b/src/main/java/com/myslotify/slotify/entity/Admin.java
@@ -3,24 +3,11 @@ package com.myslotify.slotify.entity;
 import jakarta.persistence.*;
 import lombok.Data;
 
-import java.util.UUID;
-
 @Entity
 @Data
-public class Admin {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID adminId;
-    @Column(nullable = false)
-    private String firstName;
-    @Column(nullable = false)
-    private String lastName;
-    @Column(nullable = false, unique = true)
-    private String email;
-    @Column(nullable = false, unique = true)
-    private String phone;
-    @Column(nullable = false)
-    private String password;
+@AttributeOverride(name = "id", column = @Column(name = "admin_id"))
+public class Admin extends BaseAccount {
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AdminRole role;

--- a/src/main/java/com/myslotify/slotify/entity/BaseAccount.java
+++ b/src/main/java/com/myslotify/slotify/entity/BaseAccount.java
@@ -1,0 +1,29 @@
+package com.myslotify.slotify.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.util.UUID;
+
+@MappedSuperclass
+@Data
+public abstract class BaseAccount {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false, unique = true)
+    private String phone;
+
+    @Column(nullable = false)
+    private String password;
+}

--- a/src/main/java/com/myslotify/slotify/entity/User.java
+++ b/src/main/java/com/myslotify/slotify/entity/User.java
@@ -3,28 +3,15 @@ package com.myslotify.slotify.entity;
 import jakarta.persistence.*;
 import lombok.Data;
 
-import java.util.UUID;
-
 @Entity
 @Data
-public class User {
+@AttributeOverride(name = "id", column = @Column(name = "user_id"))
+public class User extends BaseAccount {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID userId;
-    @Column(nullable = false)
-    private String firstName;
-    @Column(nullable = false)
-    private String lastName;
-    @Column(nullable = false, unique = true)
-    private String email;
-    @Column(nullable = false, unique = true)
-    private String phone;
-    @Column(nullable = false)
-    private String password;
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
+
     @Column(nullable = false)
     private boolean passwordResetRequired = false;
 }

--- a/src/main/java/com/myslotify/slotify/service/AuthServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AuthServiceImpl.java
@@ -26,6 +26,7 @@ public class AuthServiceImpl implements AuthService {
     @Autowired
     private JwtService jwtService;
 
+    @Override
     public AuthResponse login(LoginRequest request) {
         if (TenantContext.getCurrentTenant() == null) {
             Admin admin = adminRepository.findByEmail(request.getEmail())
@@ -36,7 +37,7 @@ public class AuthServiceImpl implements AuthService {
             }
 
             String token = jwtService.generateToken(admin);
-            return new AuthResponse("Login successful", token);
+            return new AuthResponse("Login successful", token, admin);
         }
 
         User user = userRepository.findByEmail(request.getEmail())
@@ -52,9 +53,10 @@ public class AuthServiceImpl implements AuthService {
 
         String token = jwtService.generateToken(user);
 
-        return new AuthResponse("Login successful", token);
+        return new AuthResponse("Login successful", token, user);
     }
 
+    @Override
     public AuthResponse resetPassword(ResetPasswordRequest request) {
         User user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(() -> new RuntimeException("User not found"));
@@ -68,6 +70,6 @@ public class AuthServiceImpl implements AuthService {
         userRepository.save(user);
 
         String token = jwtService.generateToken(user);
-        return new AuthResponse("Password reset successful", token);
+        return new AuthResponse("Password reset successful", token, user);
     }
 }

--- a/src/main/java/com/myslotify/slotify/service/JwtService.java
+++ b/src/main/java/com/myslotify/slotify/service/JwtService.java
@@ -1,15 +1,12 @@
 package com.myslotify.slotify.service;
 
-import com.myslotify.slotify.entity.User;
-import com.myslotify.slotify.entity.Admin;
+import com.myslotify.slotify.entity.BaseAccount;
 import org.springframework.stereotype.Service;
 
 public interface JwtService {
 
-    String generateToken(User user);
-    String generateToken(Admin admin);
+    String generateToken(BaseAccount account);
     String extractEmail(String token);
     String extractRole(String token);
-    boolean isTokenValid(String token, User user);
-    boolean isTokenValid(String token, Admin admin);
+    boolean isTokenValid(String token, BaseAccount account);
 }

--- a/src/main/java/com/myslotify/slotify/service/JwtServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/JwtServiceImpl.java
@@ -1,8 +1,9 @@
 package com.myslotify.slotify.service;
 
 
-import com.myslotify.slotify.entity.User;
+import com.myslotify.slotify.entity.BaseAccount;
 import com.myslotify.slotify.entity.Admin;
+import com.myslotify.slotify.entity.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -24,20 +25,10 @@ public class JwtServiceImpl implements JwtService {
         this.secretKey = secretKey;
     }
 
-    public String generateToken(User user) {
+    public String generateToken(BaseAccount account) {
         return Jwts.builder()
-                .setSubject(user.getEmail())
-                .claim("role", user.getRole().name())
-                .setIssuedAt(new Date())
-                .setExpiration(Date.from(Instant.now().plus(Duration.ofHours(12))))
-                .signWith(getKey())
-                .compact();
-    }
-
-    public String generateToken(Admin admin) {
-        return Jwts.builder()
-                .setSubject(admin.getEmail())
-                .claim("role", admin.getRole().name())
+                .setSubject(account.getEmail())
+                .claim("role", account instanceof Admin ? ((Admin) account).getRole().name() : ((User) account).getRole().name())
                 .setIssuedAt(new Date())
                 .setExpiration(Date.from(Instant.now().plus(Duration.ofHours(12))))
                 .signWith(getKey())
@@ -64,11 +55,7 @@ public class JwtServiceImpl implements JwtService {
                 .getBody();
     }
 
-    public boolean isTokenValid(String token, User user) {
-        return extractEmail(token).equals(user.getEmail());
-    }
-
-    public boolean isTokenValid(String token, Admin admin) {
-        return extractEmail(token).equals(admin.getEmail());
+    public boolean isTokenValid(String token, BaseAccount account) {
+        return extractEmail(token).equals(account.getEmail());
     }
 }

--- a/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
@@ -56,7 +56,6 @@ public class UserServiceImpl implements UserService {
         }
 
         User user = new User();
-        user.setUserId(UUID.randomUUID());
         user.setFirstName(request.getFirstName());
         user.setLastName(request.getLastName());
         user.setPhone(request.getPhone());
@@ -73,7 +72,7 @@ public class UserServiceImpl implements UserService {
     }
 
     public Employee createEmployee(CreateUserRequest request) {
-        User user = createUser(request).getUser();
+        User user = (User) createUser(request).getAccount();
 
         Employee employee = new Employee();
         employee.setUser(user);


### PR DESCRIPTION
## Summary
- add `BaseAccount` mapped superclass
- derive `Admin` and `User` from `BaseAccount`
- unify JWT service to accept `BaseAccount`
- expand AuthResponse to return admin or user account

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68433e5bf818832c851f4614d64d0155