### PR TITLE
Add PostgreSQL datasource support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Several settings can be provided either via environment variables or by editing 
 - `STRIPE_API_SECRET` (`stripe.api.secret`)
 - `STRIPE_API_PUBLIC` (`stripe.api.public`)
 - `STRIPE_PRICE_ID` (`stripe.price.id`)
+- `DB_URL` (`spring.datasource.url`)
+- `DB_USERNAME` (`spring.datasource.username`)
+- `DB_PASSWORD` (`spring.datasource.password`)
+- `DB_DRIVER` (`spring.datasource.driver-class-name`)
 
 These values configure JWT signing and Stripe integration.
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,12 +88,17 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.stripe</groupId>
-			<artifactId>stripe-java</artifactId>
-			<version>24.0.0</version>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>com.stripe</groupId>
+                        <artifactId>stripe-java</artifactId>
+                        <version>24.0.0</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <scope>runtime</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,12 @@ spring.application.name=slotify
 spring.jpa.hibernate.multi-tenancy=SCHEMA
 spring.jpa.hibernate.ddl-auto=none
 
+# Database connection
+spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/slotify}
+spring.datasource.username=${DB_USERNAME:slotify}
+spring.datasource.password=${DB_PASSWORD:password}
+spring.datasource.driver-class-name=${DB_DRIVER:org.postgresql.Driver}
+
 # SQL
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
## Summary
- add PostgreSQL JDBC driver dependency
- document datasource environment variables
- configure datasource properties

## Testing
- `./mvnw -q test` *(fails: Could not resolve parent POM)*
- `./mvnw spring-boot:run -DskipTests` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684370668434832cade3eb09ea41463c