### PR TITLE
Fix tenant admin nullable

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/Tenant.java
+++ b/src/main/java/com/myslotify/slotify/entity/Tenant.java
@@ -22,7 +22,7 @@ public class Tenant {
     @Column(nullable = false)
     private SubscriptionStatus subscriptionStatus;
     @OneToOne
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id")
     private User tenantAdmin;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/resources/db/changelog/db.changelog-system.xml
+++ b/src/main/resources/db/changelog/db.changelog-system.xml
@@ -17,9 +17,7 @@
       <column name="schema_name" type="VARCHAR(255)" >
         <constraints unique="true" nullable="false"/>
       </column>
-      <column name="user_id" type="UUID">
-        <constraints nullable="false"/>
-      </column>
+      <column name="user_id" type="UUID"/>
       <column name="created_at" type="TIMESTAMP">
         <constraints nullable="false"/>
       </column>


### PR DESCRIPTION
## Summary
- make tenant.admin optional in the schema

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6843706bbce0832caa50c27c8dad70d3