### PR TITLE
Add Stripe subscription session for tenant creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Several settings can be provided either via environment variables or by editing 
 - `STRIPE_API_SECRET` (`stripe.api.secret`)
 - `STRIPE_API_PUBLIC` (`stripe.api.public`)
 - `STRIPE_PRICE_ID` (`stripe.price.id`)
+- `STRIPE_SUCCESS_URL` (`stripe.success.url`)
+- `STRIPE_CANCEL_URL` (`stripe.cancel.url`)
 - `DB_URL` (`spring.datasource.url`)
 - `DB_USERNAME` (`spring.datasource.username`)
 - `DB_PASSWORD` (`spring.datasource.password`)

--- a/src/main/java/com/myslotify/slotify/controller/TenantController.java
+++ b/src/main/java/com/myslotify/slotify/controller/TenantController.java
@@ -1,6 +1,7 @@
 package com.myslotify.slotify.controller;
 
 import com.myslotify.slotify.dto.TenantRequest;
+import com.myslotify.slotify.dto.TenantResponse;
 import com.myslotify.slotify.entity.Tenant;
 import com.myslotify.slotify.service.TenantService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,9 +31,8 @@ public class TenantController {
     }
 
     @PostMapping
-    public ResponseEntity<Tenant> createTenant(@RequestBody TenantRequest request) {
-        Tenant tenant = tenantService.createTenant(request);
-        return ResponseEntity.ok(tenant);
+    public ResponseEntity<TenantResponse> createTenant(@RequestBody TenantRequest request) {
+        return ResponseEntity.ok(tenantService.createTenant(request));
     }
 
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/myslotify/slotify/dto/TenantResponse.java
+++ b/src/main/java/com/myslotify/slotify/dto/TenantResponse.java
@@ -1,0 +1,12 @@
+package com.myslotify.slotify.dto;
+
+import com.myslotify.slotify.entity.Tenant;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TenantResponse {
+    private Tenant tenant;
+    private String paymentUrl;
+}

--- a/src/main/java/com/myslotify/slotify/service/TenantService.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantService.java
@@ -2,6 +2,7 @@ package com.myslotify.slotify.service;
 
 import com.myslotify.slotify.dto.TenantRequest;
 import com.myslotify.slotify.entity.Tenant;
+import com.myslotify.slotify.dto.TenantResponse;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -10,7 +11,7 @@ import java.util.UUID;
 @Service
 public interface TenantService {
 
-    Tenant createTenant(TenantRequest request);
+    TenantResponse createTenant(TenantRequest request);
 
     List<Tenant> getAllTenants();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,3 +27,5 @@ app.jwt.secret=gq1HrVakbKbatpW4n+TnYRUS5g/S1TW6FILNWdpe5PqlBP73yonr8sQdpykIzrg0a
 stripe.api.secret=sk_test_51RVDWmFwBZdFT9hud9lKRvQpgWmGXyb9nReYyLN2QUhCiFlZKk9oEfcX0JfZEiNsCvXLIL4kpxTvkchWAGHwuwzJ00PQwmonF2
 stripe.api.public=pk_test_51RVDWmFwBZdFT9hu8AITcVGzwHFSLgekgO23hJYuw80nxNS2c9RhSn564YUrWUKMx4usHwCLLvZzgaVTEgPoVBaS00oj1hpx7R
 stripe.price.id=price_1RVDcqFwBZdFT9hucEWUww73
+stripe.success.url=http://localhost:8080/payment/success
+stripe.cancel.url=http://localhost:8080/payment/cancel


### PR DESCRIPTION
## Summary
- return payment URL when creating a tenant
- wire Stripe checkout session into tenant service
- document additional Stripe environment variables

## Testing
- `./mvnw -q -DskipTests install` *(fails: Non-resolvable parent POM)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68437ac11d44832cbaa93aa782fe7082