### PR TITLE
Implement global exception handling

### DIFF
--- a/src/main/java/com/myslotify/slotify/dto/ErrorResponse.java
+++ b/src/main/java/com/myslotify/slotify/dto/ErrorResponse.java
@@ -1,0 +1,10 @@
+package com.myslotify.slotify.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ErrorResponse {
+    private String message;
+}

--- a/src/main/java/com/myslotify/slotify/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/myslotify/slotify/exception/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.myslotify.slotify.exception;
+
+import com.myslotify.slotify.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+        return ResponseEntity.badRequest().body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException ex) {
+        return ResponseEntity.badRequest().body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(ex.getMessage()));
+    }
+}


### PR DESCRIPTION
## Summary
- add `ErrorResponse` DTO for error messages
- introduce `GlobalExceptionHandler` to handle runtime, illegal argument, and generic exceptions

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68437aebf43c832ca0e649ac73843d8b