### PR TITLE
Add appointment booking features

### DIFF
--- a/src/main/java/com/myslotify/slotify/repository/TimeSlotRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/TimeSlotRepository.java
@@ -8,4 +8,7 @@ import java.util.UUID;
 
 @Repository
 public interface TimeSlotRepository extends JpaRepository<TimeSlot, UUID> {
+    TimeSlot findByAppointmentAppointmentId(UUID appointmentId);
+
+    java.util.List<TimeSlot> findAllByAppointmentAppointmentId(UUID appointmentId);
 }

--- a/src/main/java/com/myslotify/slotify/service/AppointmentService.java
+++ b/src/main/java/com/myslotify/slotify/service/AppointmentService.java
@@ -1,6 +1,7 @@
 package com.myslotify.slotify.service;
 
 import com.myslotify.slotify.entity.Appointment;
+import org.springframework.security.core.Authentication;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -10,4 +11,9 @@ public interface AppointmentService {
     Appointment getAppointment(UUID id);
     List<Appointment> getAppointmentsBetween(LocalDateTime start, LocalDateTime end);
     void sendRemindersForUpcomingAppointments();
+
+    Appointment createAppointment(UUID slotId, UUID serviceId, Authentication auth);
+    Appointment createAppointmentForCustomer(UUID slotId, UUID serviceId, UUID customerId, Authentication auth);
+    void cancelAppointment(UUID appointmentId, Authentication auth);
+    void cancelAppointmentAsEmployee(UUID appointmentId, Authentication auth);
 }

--- a/src/test/java/com/myslotify/slotify/service/AppointmentServiceImplTest.java
+++ b/src/test/java/com/myslotify/slotify/service/AppointmentServiceImplTest.java
@@ -1,0 +1,114 @@
+package com.myslotify.slotify.service;
+
+import com.myslotify.slotify.entity.*;
+import com.myslotify.slotify.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AppointmentServiceImplTest {
+
+    @Mock
+    private AppointmentRepository appointmentRepository;
+    @Mock
+    private TimeSlotRepository timeSlotRepository;
+    @Mock
+    private ServiceRepository serviceRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private EmployeeRepository employeeRepository;
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private AppointmentServiceImpl appointmentService;
+
+    private Authentication auth;
+    private User user;
+    private Employee employee;
+    private TimeSlot slot1;
+    private TimeSlot slot2;
+    private Service service;
+
+    @BeforeEach
+    void setUp() {
+        auth = new TestingAuthenticationToken("user@example.com", null);
+        user = new User();
+        user.setId(UUID.randomUUID());
+        user.setEmail("user@example.com");
+
+        employee = new Employee();
+        employee.setEmployeeId(UUID.randomUUID());
+
+        EmployeeAvailability availability = new EmployeeAvailability();
+        availability.setEmployee(employee);
+        availability.setDate(LocalDate.now());
+
+        slot1 = new TimeSlot();
+        slot1.setSlotId(UUID.randomUUID());
+        slot1.setStartTime(LocalTime.of(9,0));
+        slot1.setEndTime(LocalTime.of(9,15));
+        slot1.setAvailability(availability);
+        slot1.setStatus(SlotStatus.AVAILABLE);
+
+        slot2 = new TimeSlot();
+        slot2.setSlotId(UUID.randomUUID());
+        slot2.setStartTime(LocalTime.of(9,15));
+        slot2.setEndTime(LocalTime.of(9,30));
+        slot2.setAvailability(availability);
+        slot2.setStatus(SlotStatus.AVAILABLE);
+
+        java.util.List<TimeSlot> slots = java.util.Arrays.asList(slot1, slot2);
+        availability.setTimeSlots(slots);
+
+        service = new Service();
+        service.setServiceId(UUID.randomUUID());
+        service.setDuration(Interval.MINUTES_30);
+
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(user));
+        when(timeSlotRepository.findById(slot1.getSlotId())).thenReturn(Optional.of(slot1));
+        when(serviceRepository.findById(service.getServiceId())).thenReturn(Optional.of(service));
+        when(appointmentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+    }
+
+    @Test
+    void createAppointmentSchedulesSlot() {
+        Appointment appt = appointmentService.createAppointment(slot1.getSlotId(), service.getServiceId(), auth);
+
+        assertNotNull(appt);
+        assertEquals(AppointmentStatus.SCHEDULED, appt.getStatus());
+        assertEquals(SlotStatus.SCHEDULED, slot1.getStatus());
+        assertEquals(SlotStatus.SCHEDULED, slot2.getStatus());
+        verify(timeSlotRepository).saveAll(any());
+    }
+
+    @Test
+    void cancelAppointmentMarksSlotAvailable() {
+        Appointment appt = appointmentService.createAppointment(slot1.getSlotId(), service.getServiceId(), auth);
+        when(appointmentRepository.findById(appt.getAppointmentId())).thenReturn(Optional.of(appt));
+        when(timeSlotRepository.findAllByAppointmentAppointmentId(appt.getAppointmentId())).thenReturn(java.util.Arrays.asList(slot1, slot2));
+
+        appointmentService.cancelAppointment(appt.getAppointmentId(), auth);
+
+        assertEquals(AppointmentStatus.CANCELLED, appt.getStatus());
+        assertEquals(SlotStatus.AVAILABLE, slot1.getStatus());
+        assertEquals(SlotStatus.AVAILABLE, slot2.getStatus());
+        verify(timeSlotRepository, times(2)).saveAll(any());
+    }
+}


### PR DESCRIPTION
## Summary
- allow fetching TimeSlot by appointment
- expand appointment service API
- implement booking and cancel operations with authorization checks
- support appointments spanning multiple slots
- test appointment booking service

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Non-resolvable parent POM)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684455b471e0832cb8810ab63390da38