### PR TITLE
Refactor Employee to extend account details

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/Employee.java
+++ b/src/main/java/com/myslotify/slotify/entity/Employee.java
@@ -2,20 +2,16 @@ package com.myslotify.slotify.entity;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 import java.util.List;
 import java.util.UUID;
 
 @Entity
 @Data
-public class Employee {
-    @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID employeeId;
-
-    @OneToOne
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+@EqualsAndHashCode(callSuper = true)
+@AttributeOverride(name = "id", column = @Column(name = "employee_id"))
+public class Employee extends User {
 
     @OneToMany(mappedBy = "employee", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<EmployeeAvailability> availabilities;

--- a/src/main/java/com/myslotify/slotify/filter/JwtAuthFilter.java
+++ b/src/main/java/com/myslotify/slotify/filter/JwtAuthFilter.java
@@ -2,8 +2,10 @@ package com.myslotify.slotify.filter;
 
 import com.myslotify.slotify.entity.Admin;
 import com.myslotify.slotify.entity.User;
+import com.myslotify.slotify.entity.Employee;
 import com.myslotify.slotify.repository.AdminRepository;
 import com.myslotify.slotify.repository.UserRepository;
+import com.myslotify.slotify.repository.EmployeeRepository;
 import com.myslotify.slotify.util.TenantContext;
 import com.myslotify.slotify.service.JwtService;
 import jakarta.servlet.FilterChain;
@@ -25,11 +27,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private final JwtService jwtService;
     private final UserRepository userRepository;
     private final AdminRepository adminRepository;
+    private final EmployeeRepository employeeRepository;
 
-    public JwtAuthFilter(JwtService jwtService, UserRepository userRepository, AdminRepository adminRepository) {
+    public JwtAuthFilter(JwtService jwtService, UserRepository userRepository, AdminRepository adminRepository, EmployeeRepository employeeRepository) {
         this.jwtService = jwtService;
         this.userRepository = userRepository;
         this.adminRepository = adminRepository;
+        this.employeeRepository = employeeRepository;
     }
 
     @Override
@@ -56,7 +60,14 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 }
             } else {
                 User user = userRepository.findByEmail(email).orElse(null);
-                if (user != null && jwtService.isTokenValid(token, user)) {
+                if (user == null) {
+                    Employee employee = employeeRepository.findByEmail(email).orElse(null);
+                    if (employee != null && jwtService.isTokenValid(token, employee)) {
+                        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                                employee, null, List.of(new SimpleGrantedAuthority("ROLE_" + employee.getRole().name())));
+                        SecurityContextHolder.getContext().setAuthentication(auth);
+                    }
+                } else if (jwtService.isTokenValid(token, user)) {
                     UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
                             user, null, List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())));
                     SecurityContextHolder.getContext().setAuthentication(auth);

--- a/src/main/java/com/myslotify/slotify/repository/EmployeeAvailabilityRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/EmployeeAvailabilityRepository.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @Repository
 public interface EmployeeAvailabilityRepository extends JpaRepository<EmployeeAvailability, UUID> {
 
-    List<EmployeeAvailability> findByEmployeeEmployeeId(UUID employeeId);
+    List<EmployeeAvailability> findByEmployeeId(UUID employeeId);
 
     boolean existsByEmployeeAndDate(Employee employee, LocalDate date);
 }

--- a/src/main/java/com/myslotify/slotify/repository/EmployeeRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/EmployeeRepository.java
@@ -9,5 +9,5 @@ import java.util.UUID;
 
 @Repository
 public interface EmployeeRepository extends JpaRepository<Employee, UUID> {
-    Optional<Employee> findByUserEmail(String email);
+    Optional<Employee> findByEmail(String email);
 }

--- a/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
@@ -53,7 +53,7 @@ public class AppointmentServiceImpl implements AppointmentService {
 
     private Employee getCurrentEmployee(Authentication auth) {
         String email = auth.getName();
-        return employeeRepository.findByUserEmail(email)
+        return employeeRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("Employee not found"));
     }
 
@@ -68,7 +68,7 @@ public class AppointmentServiceImpl implements AppointmentService {
         Employee employee = getCurrentEmployee(auth);
         TimeSlot slot = timeSlotRepository.findById(slotId)
                 .orElseThrow(() -> new RuntimeException("Time slot not found"));
-        if (!slot.getAvailability().getEmployee().getEmployeeId().equals(employee.getEmployeeId())) {
+        if (!slot.getAvailability().getEmployee().getId().equals(employee.getId())) {
             throw new RuntimeException("Unauthorized to book this slot");
         }
         User customer = userRepository.findById(customerId)
@@ -141,7 +141,7 @@ public class AppointmentServiceImpl implements AppointmentService {
     public void cancelAppointmentAsEmployee(UUID appointmentId, Authentication auth) {
         Employee employee = getCurrentEmployee(auth);
         Appointment appointment = getAppointment(appointmentId);
-        if (!appointment.getEmployee().getEmployeeId().equals(employee.getEmployeeId())) {
+        if (!appointment.getEmployee().getId().equals(employee.getId())) {
             throw new RuntimeException("Unauthorized to cancel this appointment");
         }
         cancelAppointmentInternal(appointment);

--- a/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
@@ -32,13 +32,13 @@ public class AvailabilityServiceImpl implements AvailabilityService {
 
     private Employee getCurrentEmployee(Authentication authentication) {
         String email = authentication.getName();
-        return employeeRepository.findByUserEmail(email)
+        return employeeRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("Employee not found"));
     }
 
     public List<EmployeeAvailability> getAvailabilityForEmployee(Authentication auth) {
         Employee employee = getCurrentEmployee(auth);
-        return availabilityRepository.findByEmployeeEmployeeId(employee.getEmployeeId());
+        return availabilityRepository.findByEmployeeId(employee.getId());
     }
 
     public List<EmployeeAvailability> createAvailabilityForDates(CreateAvailabilityRequest request, Authentication auth) {
@@ -96,7 +96,7 @@ public class AvailabilityServiceImpl implements AvailabilityService {
         EmployeeAvailability availability = availabilityRepository.findById(availabilityId)
                 .orElseThrow(() -> new RuntimeException("Availability not found"));
 
-        if (!availability.getEmployee().getEmployeeId().equals(employee.getEmployeeId())) {
+        if (!availability.getEmployee().getId().equals(employee.getId())) {
             throw new RuntimeException("Unauthorized to delete this availability");
         }
 
@@ -109,7 +109,7 @@ public class AvailabilityServiceImpl implements AvailabilityService {
         TimeSlot slot = timeSlotRepository.findById(timeSlotId)
                 .orElseThrow(() -> new RuntimeException("Time slot not found"));
 
-        if (!slot.getAvailability().getEmployee().getEmployeeId().equals(employee.getEmployeeId())) {
+        if (!slot.getAvailability().getEmployee().getId().equals(employee.getId())) {
             throw new RuntimeException("Unauthorized to block this time slot");
         }
 
@@ -127,7 +127,7 @@ public class AvailabilityServiceImpl implements AvailabilityService {
         TimeSlot slot = timeSlotRepository.findById(timeSlotId)
                 .orElseThrow(() -> new RuntimeException("Time slot not found"));
 
-        if (!slot.getAvailability().getEmployee().getEmployeeId().equals(employee.getEmployeeId())) {
+        if (!slot.getAvailability().getEmployee().getId().equals(employee.getId())) {
             throw new RuntimeException("Unauthorized to unblock this time slot");
         }
 

--- a/src/main/java/com/myslotify/slotify/service/JwtServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/JwtServiceImpl.java
@@ -4,6 +4,7 @@ package com.myslotify.slotify.service;
 import com.myslotify.slotify.entity.BaseAccount;
 import com.myslotify.slotify.entity.Admin;
 import com.myslotify.slotify.entity.User;
+import com.myslotify.slotify.entity.Employee;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -26,9 +27,18 @@ public class JwtServiceImpl implements JwtService {
     }
 
     public String generateToken(BaseAccount account) {
+        String role;
+        if (account instanceof Admin admin) {
+            role = admin.getRole().name();
+        } else if (account instanceof Employee employee) {
+            role = employee.getRole().name();
+        } else {
+            role = ((User) account).getRole().name();
+        }
+
         return Jwts.builder()
                 .setSubject(account.getEmail())
-                .claim("role", account instanceof Admin ? ((Admin) account).getRole().name() : ((User) account).getRole().name())
+                .claim("role", role)
                 .setIssuedAt(new Date())
                 .setExpiration(Date.from(Instant.now().plus(Duration.ofHours(12))))
                 .signWith(getKey())

--- a/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
@@ -77,14 +77,24 @@ public class UserServiceImpl implements UserService {
     }
 
     public Employee createEmployee(CreateUserRequest request) {
-        User user = (User) createUser(request).getAccount();
+        Optional<Employee> existing = employeeRepository.findByEmail(request.getEmail());
+        if (existing.isPresent()) {
+            throw new RuntimeException("Employee already exists");
+        }
 
         Employee employee = new Employee();
-        employee.setUser(user);
+        employee.setFirstName(request.getFirstName());
+        employee.setLastName(request.getLastName());
+        employee.setPhone(request.getPhone());
+        employee.setEmail(request.getEmail());
+        employee.setPassword(passwordEncoder.encode(request.getPassword()));
+        employee.setRole(Role.EMPLOYEE);
+        employee.setPasswordResetRequired(true);
 
         Employee saved = employeeRepository.save(employee);
+
         notificationService.sendEmail(
-                user.getEmail(),
+                employee.getEmail(),
                 "Employee Account Created",
                 "Your account has been created. Please log in to start managing appointments.");
 

--- a/src/test/java/com/myslotify/slotify/service/AppointmentServiceImplTest.java
+++ b/src/test/java/com/myslotify/slotify/service/AppointmentServiceImplTest.java
@@ -54,7 +54,7 @@ class AppointmentServiceImplTest {
         user.setEmail("user@example.com");
 
         employee = new Employee();
-        employee.setEmployeeId(UUID.randomUUID());
+        employee.setId(UUID.randomUUID());
 
         EmployeeAvailability availability = new EmployeeAvailability();
         availability.setEmployee(employee);

--- a/src/test/java/com/myslotify/slotify/service/AvailabilityServiceImplTest.java
+++ b/src/test/java/com/myslotify/slotify/service/AvailabilityServiceImplTest.java
@@ -47,13 +47,11 @@ class AvailabilityServiceImplTest {
     @BeforeEach
     void setUp() {
         auth = new TestingAuthenticationToken("employee@example.com", null);
-        User user = new User();
-        user.setEmail("employee@example.com");
         employee = new Employee();
-        employee.setEmployeeId(UUID.randomUUID());
-        employee.setUser(user);
+        employee.setId(UUID.randomUUID());
+        employee.setEmail("employee@example.com");
 
-        when(employeeRepository.findByUserEmail("employee@example.com"))
+        when(employeeRepository.findByEmail("employee@example.com"))
                 .thenReturn(Optional.of(employee));
         when(availabilityRepository.save(any(EmployeeAvailability.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));


### PR DESCRIPTION
## Summary
- embed account details into `Employee` by extending `User`
- update repositories and services for new model
- allow authentication of employees
- adjust JWT handling and tests

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68445912a5fc832cb5db7e76f189f299