### PR TITLE
Add method to fetch employee available time slots

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/AvailabilityController.java
+++ b/src/main/java/com/myslotify/slotify/controller/AvailabilityController.java
@@ -2,6 +2,7 @@ package com.myslotify.slotify.controller;
 
 import com.myslotify.slotify.dto.CreateAvailabilityRequest;
 import com.myslotify.slotify.entity.EmployeeAvailability;
+import com.myslotify.slotify.entity.TimeSlot;
 import com.myslotify.slotify.service.AvailabilityService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -56,5 +57,11 @@ public class AvailabilityController {
     public ResponseEntity<Void> unblockTimeSlot(@PathVariable UUID slotId, Authentication auth) {
         availabilityService.unblockTimeSlot(slotId, auth);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/available-slots")
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    public ResponseEntity<List<TimeSlot>> getAvailableSlots(Authentication auth) {
+        return ResponseEntity.ok(availabilityService.getAvailableTimeSlotsForEmployee(auth));
     }
 }

--- a/src/main/java/com/myslotify/slotify/controller/TimeSlotController.java
+++ b/src/main/java/com/myslotify/slotify/controller/TimeSlotController.java
@@ -1,0 +1,25 @@
+package com.myslotify.slotify.controller;
+
+import com.myslotify.slotify.entity.TimeSlot;
+import com.myslotify.slotify.service.AvailabilityService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/slots")
+public class TimeSlotController {
+
+    private final AvailabilityService availabilityService;
+
+    public TimeSlotController(AvailabilityService availabilityService) {
+        this.availabilityService = availabilityService;
+    }
+
+    @GetMapping("/{employeeId}")
+    public ResponseEntity<List<TimeSlot>> getAvailableSlotsForEmployee(@PathVariable UUID employeeId) {
+        return ResponseEntity.ok(availabilityService.getAvailableTimeSlotsForEmployee(employeeId));
+    }
+}

--- a/src/main/java/com/myslotify/slotify/repository/TimeSlotRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/TimeSlotRepository.java
@@ -1,5 +1,6 @@
 package com.myslotify.slotify.repository;
 
+import com.myslotify.slotify.entity.SlotStatus;
 import com.myslotify.slotify.entity.TimeSlot;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +12,6 @@ public interface TimeSlotRepository extends JpaRepository<TimeSlot, UUID> {
     TimeSlot findByAppointmentAppointmentId(UUID appointmentId);
 
     java.util.List<TimeSlot> findAllByAppointmentAppointmentId(UUID appointmentId);
+
+    java.util.List<TimeSlot> findAllByAvailabilityEmployeeEmployeeIdAndStatus(UUID employeeId, SlotStatus status);
 }

--- a/src/main/java/com/myslotify/slotify/service/AvailabilityService.java
+++ b/src/main/java/com/myslotify/slotify/service/AvailabilityService.java
@@ -2,6 +2,7 @@ package com.myslotify.slotify.service;
 
 import com.myslotify.slotify.dto.CreateAvailabilityRequest;
 import com.myslotify.slotify.entity.EmployeeAvailability;
+import com.myslotify.slotify.entity.TimeSlot;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
@@ -16,4 +17,6 @@ public interface AvailabilityService {
     void deleteAvailability(UUID availabilityId, Authentication auth);
     void blockTimeSlot(UUID timeSlotId, Authentication auth);
     void unblockTimeSlot(UUID timeSlotId, Authentication auth);
+    List<TimeSlot> getAvailableTimeSlotsForEmployee(Authentication auth);
+    List<TimeSlot> getAvailableTimeSlotsForEmployee(UUID employeeId);
 }

--- a/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
@@ -138,4 +138,18 @@ public class AvailabilityServiceImpl implements AvailabilityService {
         slot.setStatus(SlotStatus.AVAILABLE);
         timeSlotRepository.save(slot);
     }
+
+    public List<TimeSlot> getAvailableTimeSlotsForEmployee(Authentication auth) {
+        Employee employee = getCurrentEmployee(auth);
+        return timeSlotRepository
+                .findAllByAvailabilityEmployeeEmployeeIdAndStatus(employee.getEmployeeId(), SlotStatus.AVAILABLE);
+    }
+
+    public List<TimeSlot> getAvailableTimeSlotsForEmployee(UUID employeeId) {
+        if (!employeeRepository.existsById(employeeId)) {
+            throw new RuntimeException("Employee not found");
+        }
+        return timeSlotRepository
+                .findAllByAvailabilityEmployeeEmployeeIdAndStatus(employeeId, SlotStatus.AVAILABLE);
+    }
 }


### PR DESCRIPTION
## Summary
- extend `AvailabilityService` with method for requesting slots by employee id
- implement the query in `AvailabilityServiceImpl`
- expose employee slot retrieval under `/api/availability/available-slots`
- add `/api/slots/{employeeId}` endpoint for users

## Testing
- `./mvnw -q -DskipTests package` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68445c3b5780832ca5643c2797704ecd