### PR TITLE
Fix timeslot repository method name

### DIFF
--- a/src/main/java/com/myslotify/slotify/repository/TimeSlotRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/TimeSlotRepository.java
@@ -13,5 +13,5 @@ public interface TimeSlotRepository extends JpaRepository<TimeSlot, UUID> {
 
     java.util.List<TimeSlot> findAllByAppointmentAppointmentId(UUID appointmentId);
 
-    java.util.List<TimeSlot> findAllByAvailabilityEmployeeEmployeeIdAndStatus(UUID employeeId, SlotStatus status);
+    java.util.List<TimeSlot> findAllByAvailabilityEmployeeIdAndStatus(UUID employeeId, SlotStatus status);
 }

--- a/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
@@ -142,7 +142,7 @@ public class AvailabilityServiceImpl implements AvailabilityService {
     public List<TimeSlot> getAvailableTimeSlotsForEmployee(Authentication auth) {
         Employee employee = getCurrentEmployee(auth);
         return timeSlotRepository
-                .findAllByAvailabilityEmployeeEmployeeIdAndStatus(employee.getId(), SlotStatus.AVAILABLE);
+                .findAllByAvailabilityEmployeeIdAndStatus(employee.getId(), SlotStatus.AVAILABLE);
     }
 
     public List<TimeSlot> getAvailableTimeSlotsForEmployee(UUID employeeId) {
@@ -150,6 +150,6 @@ public class AvailabilityServiceImpl implements AvailabilityService {
             throw new RuntimeException("Employee not found");
         }
         return timeSlotRepository
-                .findAllByAvailabilityEmployeeEmployeeIdAndStatus(employeeId, SlotStatus.AVAILABLE);
+                .findAllByAvailabilityEmployeeIdAndStatus(employeeId, SlotStatus.AVAILABLE);
     }
 }


### PR DESCRIPTION
## Summary
- correct path property for querying `TimeSlot` entities
- update service calls to use new repository method

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684471e8c3f0832ca55d0cf9a7641c22