### PR TITLE
Add Swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,8 @@ X-Tenant-ID: my_tenant
 
 The filter stores the tenant in a thread-local context so repositories and services can resolve the correct schema for the request.
 
+
+## API documentation
+
+The project uses springdoc-openapi to expose Swagger UI. Once the application is running, navigate to [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html) to explore available endpoints. The raw OpenAPI spec can be retrieved from [http://localhost:8080/v3/api-docs](http://localhost:8080/v3/api-docs).
+

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
                         <artifactId>twilio</artifactId>
                         <version>10.9.1</version>
                 </dependency>
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.8.6</version>
+                </dependency>
         </dependencies>
 
 	<build>

--- a/src/main/java/com/myslotify/slotify/configuration/OpenApiConfig.java
+++ b/src/main/java/com/myslotify/slotify/configuration/OpenApiConfig.java
@@ -1,0 +1,16 @@
+package com.myslotify.slotify.configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(
+                title = "Slotify API",
+                version = "v1",
+                description = "API documentation for Slotify"
+        )
+)
+public class OpenApiConfig {
+}

--- a/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
+++ b/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
@@ -29,7 +29,12 @@ public class SecurityConfig {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
## Summary
- integrate springdoc-openapi to expose Swagger UI
- configure OpenAPI with application info
- allow unauthenticated access to Swagger endpoints
- document how to access the Swagger UI

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684473141ea8832c842616b6c11658fd