### PR TITLE
Fix UUID generation and subscription logs

### DIFF
--- a/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
@@ -111,7 +111,6 @@ public class AppointmentServiceImpl implements AppointmentService {
         }
 
         Appointment appointment = new Appointment();
-        appointment.setAppointmentId(UUID.randomUUID());
         appointment.setEmployee(slot.getAvailability().getEmployee());
         appointment.setCustomer(customer);
         appointment.setAppointmentTime(LocalDateTime.of(slot.getAvailability().getDate(), slot.getStartTime()));

--- a/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
@@ -57,7 +57,6 @@ public class AvailabilityServiceImpl implements AvailabilityService {
             }
 
             EmployeeAvailability availability = new EmployeeAvailability();
-            availability.setAvailabilityId(UUID.randomUUID());
             availability.setDate(date);
             availability.setEmployee(employee);
             availability = availabilityRepository.save(availability);
@@ -76,7 +75,6 @@ public class AvailabilityServiceImpl implements AvailabilityService {
 
             while (!current.plusMinutes(intervalMinutes).isAfter(request.getShiftEnd())) {
                 TimeSlot slot = new TimeSlot();
-                slot.setSlotId(UUID.randomUUID());
                 slot.setStartTime(current);
                 slot.setEndTime(current.plusMinutes(intervalMinutes));
                 slot.setStatus(SlotStatus.AVAILABLE);

--- a/src/main/java/com/myslotify/slotify/service/ManagementServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/ManagementServiceImpl.java
@@ -30,7 +30,6 @@ public class ManagementServiceImpl implements ManagementService {
 
     public Service createService(CreateServiceRequest request) {
         Service service = new Service();
-        service.setServiceId(UUID.randomUUID());
         service.setName(request.getName());
         service.setDescription(request.getDescription());
         service.setDuration(request.getDuration());

--- a/src/main/java/com/myslotify/slotify/service/SubscriptionChecker.java
+++ b/src/main/java/com/myslotify/slotify/service/SubscriptionChecker.java
@@ -3,6 +3,8 @@ package com.myslotify.slotify.service;
 import com.myslotify.slotify.entity.SubscriptionStatus;
 import com.myslotify.slotify.entity.Tenant;
 import com.myslotify.slotify.repository.TenantRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -10,6 +12,8 @@ import java.util.List;
 
 @Service
 public class SubscriptionChecker {
+
+    private static final Logger logger = LoggerFactory.getLogger(SubscriptionChecker.class);
 
     private final TenantRepository tenantRepository;
     private final StripeService stripeService;
@@ -35,7 +39,8 @@ public class SubscriptionChecker {
                     tenant.setSubscriptionStatus(SubscriptionStatus.INACTIVE);
                     tenantRepository.save(tenant);
                 }
-            } catch (Exception ignored) {
+            } catch (Exception ex) {
+                logger.error("Error checking subscription for tenant {}", tenant.getTenantId(), ex);
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove manual UUID assignments in service layer
- log `SubscriptionChecker` exceptions for visibility

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68447776cc10832ca4537095adf6aadd