### PR TITLE
Add tenant branding fields

### DIFF
--- a/src/main/java/com/myslotify/slotify/dto/TenantRequest.java
+++ b/src/main/java/com/myslotify/slotify/dto/TenantRequest.java
@@ -11,4 +11,17 @@ public class TenantRequest {
     private String description;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    private String motto;
+    private String address;
+    private String phone;
+    private String tiktok;
+    private String instagram;
+    private String textColour;
+    private String backgroundColour;
+    private String borderColour;
+    private String font;
+
+    private byte[] logo;
+    private byte[] coverPicture;
 }

--- a/src/main/java/com/myslotify/slotify/entity/Tenant.java
+++ b/src/main/java/com/myslotify/slotify/entity/Tenant.java
@@ -26,4 +26,19 @@ public class Tenant {
     private User tenantAdmin;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    private String motto;
+    private String address;
+    private String phone;
+    private String tiktok;
+    private String instagram;
+    private String textColour;
+    private String backgroundColour;
+    private String borderColour;
+    private String font;
+
+    @Lob
+    private byte[] logo;
+    @Lob
+    private byte[] coverPicture;
 }

--- a/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
@@ -59,6 +59,17 @@ public class TenantServiceImpl implements TenantService {
         tenant.setName(request.getName());
         tenant.setSchemaName(request.getSchemaName());
         tenant.setDescription(request.getDescription());
+        tenant.setMotto(request.getMotto());
+        tenant.setAddress(request.getAddress());
+        tenant.setPhone(request.getPhone());
+        tenant.setTiktok(request.getTiktok());
+        tenant.setInstagram(request.getInstagram());
+        tenant.setTextColour(request.getTextColour());
+        tenant.setBackgroundColour(request.getBackgroundColour());
+        tenant.setBorderColour(request.getBorderColour());
+        tenant.setFont(request.getFont());
+        tenant.setLogo(request.getLogo());
+        tenant.setCoverPicture(request.getCoverPicture());
         tenant.setCreatedAt(LocalDateTime.now());
         tenant.setSubscriptionStatus(SubscriptionStatus.PENDING);
 

--- a/src/main/resources/db/changelog/db.changelog-system.xml
+++ b/src/main/resources/db/changelog/db.changelog-system.xml
@@ -24,6 +24,17 @@
       <column name="updated_at" type="TIMESTAMP">
         <constraints nullable="false"/>
       </column>
+      <column name="motto" type="VARCHAR(255)"/>
+      <column name="address" type="VARCHAR(255)"/>
+      <column name="phone" type="VARCHAR(255)"/>
+      <column name="tiktok" type="VARCHAR(255)"/>
+      <column name="instagram" type="VARCHAR(255)"/>
+      <column name="text_colour" type="VARCHAR(255)"/>
+      <column name="background_colour" type="VARCHAR(255)"/>
+      <column name="border_colour" type="VARCHAR(255)"/>
+      <column name="font" type="VARCHAR(255)"/>
+      <column name="logo" type="BYTEA"/>
+      <column name="cover_picture" type="BYTEA"/>
     </createTable>
   </changeSet>
   <changeSet id="create-admin-table" author="nikola">


### PR DESCRIPTION
## Summary
- extend `TenantRequest` with phone, theme fields, and binary logo/cover image
- extend `Tenant` entity with phone, theme fields and logo/cover picture blobs
- populate new fields when creating a tenant
- update Liquibase changelog for new columns

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684484b32864832cabc3bc9bdceed8ba