### PR TITLE
Fix reminder job spamming

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/Appointment.java
+++ b/src/main/java/com/myslotify/slotify/entity/Appointment.java
@@ -31,4 +31,7 @@ public class Appointment {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AppointmentStatus status;
+
+    @Column(nullable = false)
+    private boolean reminderSent = false;
 }

--- a/src/main/java/com/myslotify/slotify/repository/AppointmentRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/AppointmentRepository.java
@@ -11,4 +11,6 @@ import java.util.UUID;
 @Repository
 public interface AppointmentRepository extends JpaRepository<Appointment, UUID> {
     List<Appointment> findByAppointmentTimeBetween(LocalDateTime start, LocalDateTime end);
+
+    List<Appointment> findByAppointmentTimeBetweenAndReminderSentFalse(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
@@ -116,6 +116,7 @@ public class AppointmentServiceImpl implements AppointmentService {
         appointment.setAppointmentTime(LocalDateTime.of(slot.getAvailability().getDate(), slot.getStartTime()));
         appointment.setService(service);
         appointment.setStatus(AppointmentStatus.SCHEDULED);
+        appointment.setReminderSent(false);
 
         appointment = appointmentRepository.save(appointment);
 
@@ -168,9 +169,14 @@ public class AppointmentServiceImpl implements AppointmentService {
     public void sendRemindersForUpcomingAppointments() {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime tomorrow = now.plusHours(24);
-        List<Appointment> upcoming = getAppointmentsBetween(now, tomorrow);
+        List<Appointment> upcoming = appointmentRepository
+                .findByAppointmentTimeBetweenAndReminderSentFalse(now, tomorrow);
         for (Appointment appt : upcoming) {
             notificationService.sendAppointmentReminder(appt);
+            appt.setReminderSent(true);
+        }
+        if (!upcoming.isEmpty()) {
+            appointmentRepository.saveAll(upcoming);
         }
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-tenant.xml
+++ b/src/main/resources/db/changelog/db.changelog-tenant.xml
@@ -102,6 +102,9 @@
       <column name="status" type="VARCHAR(50)">
         <constraints nullable="false"/>
       </column>
+      <column name="reminder_sent" type="BOOLEAN" defaultValueBoolean="false">
+        <constraints nullable="false"/>
+      </column>
     </createTable>
   </changeSet>
 </databaseChangeLog>

--- a/src/test/java/com/myslotify/slotify/service/AppointmentServiceImplTest.java
+++ b/src/test/java/com/myslotify/slotify/service/AppointmentServiceImplTest.java
@@ -111,4 +111,22 @@ class AppointmentServiceImplTest {
         assertEquals(SlotStatus.AVAILABLE, slot2.getStatus());
         verify(timeSlotRepository, times(2)).saveAll(any());
     }
+
+    @Test
+    void sendRemindersMarksAppointments() {
+        Appointment appt = new Appointment();
+        appt.setAppointmentTime(java.time.LocalDateTime.now().plusHours(1));
+        appt.setService(service);
+        appt.setCustomer(user);
+        appt.setStatus(AppointmentStatus.SCHEDULED);
+
+        when(appointmentRepository.findByAppointmentTimeBetweenAndReminderSentFalse(any(), any()))
+                .thenReturn(java.util.Collections.singletonList(appt));
+
+        appointmentService.sendRemindersForUpcomingAppointments();
+
+        assertTrue(appt.isReminderSent());
+        verify(notificationService).sendAppointmentReminder(appt);
+        verify(appointmentRepository).saveAll(any());
+    }
 }


### PR DESCRIPTION
## Summary
- add `reminder_sent` column directly in appointment table creation
- test scheduled reminders flag appointments

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684c7dd1c13c832caf2a037c3e2c77fd