### PR TITLE
Add password reset flag to login response

### DIFF
--- a/src/main/java/com/myslotify/slotify/dto/AuthResponse.java
+++ b/src/main/java/com/myslotify/slotify/dto/AuthResponse.java
@@ -10,4 +10,5 @@ public class AuthResponse {
     public String message;
     public String token;
     public BaseAccount account;
+    public boolean passwordResetRequired;
 }

--- a/src/main/java/com/myslotify/slotify/service/AuthServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AuthServiceImpl.java
@@ -61,7 +61,7 @@ public class AuthServiceImpl implements AuthService {
             }
 
             String token = jwtService.generateToken(admin);
-            return new AuthResponse("Login successful", token, admin);
+            return new AuthResponse("Login successful", token, admin, false);
         }
 
         Tenant tenant = tenantRepository.findBySchemaName(TenantContext.getCurrentTenant())
@@ -77,13 +77,13 @@ public class AuthServiceImpl implements AuthService {
             throw new UnauthorizedException("Invalid credentials");
         }
 
-        if (account.isPasswordResetRequired()) {
-            throw new UnauthorizedException("You must reset your password before logging in.");
-        }
+        boolean resetRequired = account.isPasswordResetRequired();
 
         String token = jwtService.generateToken(account);
 
-        return new AuthResponse("Login successful", token, account);
+        String message = resetRequired ? "Password reset required" : "Login successful";
+
+        return new AuthResponse(message, token, account, resetRequired);
     }
 
     @Override
@@ -100,6 +100,6 @@ public class AuthServiceImpl implements AuthService {
         userRepository.save(user);
 
         String token = jwtService.generateToken(user);
-        return new AuthResponse("Password reset successful", token, user);
+        return new AuthResponse("Password reset successful", token, user, false);
     }
 }

--- a/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
@@ -75,7 +75,7 @@ public class UserServiceImpl implements UserService {
 
         String token = jwtService.generateToken(user);
 
-        return new AuthResponse("User registered successfully", token, user);
+        return new AuthResponse("User registered successfully", token, user, user.isPasswordResetRequired());
     }
 
     public Employee createEmployee(CreateUserRequest request) {

--- a/src/test/java/com/myslotify/slotify/controller/AuthControllerTest.java
+++ b/src/test/java/com/myslotify/slotify/controller/AuthControllerTest.java
@@ -33,7 +33,7 @@ class AuthControllerTest {
         LoginRequest request = new LoginRequest();
         request.email = "test@example.com";
         request.password = "pass";
-        Mockito.when(authService.login(Mockito.any())).thenReturn(new AuthResponse("ok", "token", null));
+        Mockito.when(authService.login(Mockito.any())).thenReturn(new AuthResponse("ok", "token", null, false));
 
         mockMvc.perform(post("/api/auth/login")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -44,7 +44,7 @@ class AuthControllerTest {
     @Test
     void resetPasswordEndpointReturnsOk() throws Exception {
         ResetPasswordRequest request = new ResetPasswordRequest();
-        Mockito.when(authService.resetPassword(Mockito.any())).thenReturn(new AuthResponse("ok", "token", null));
+        Mockito.when(authService.resetPassword(Mockito.any())).thenReturn(new AuthResponse("ok", "token", null, false));
 
         mockMvc.perform(post("/api/auth/reset-password")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/myslotify/slotify/service/AuthServiceImplTest.java
+++ b/src/test/java/com/myslotify/slotify/service/AuthServiceImplTest.java
@@ -62,6 +62,7 @@ class AuthServiceImplTest {
         AuthResponse response = authService.login(request);
         assertEquals("token", response.getToken());
         assertEquals(admin, response.getAccount());
+        assertFalse(response.isPasswordResetRequired());
     }
 
     @Test
@@ -85,6 +86,7 @@ class AuthServiceImplTest {
         AuthResponse response = authService.login(request);
         assertEquals("token", response.getToken());
         assertEquals(user, response.getAccount());
+        assertFalse(response.isPasswordResetRequired());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- carry password reset requirement flag in `AuthResponse`
- include the flag in auth and user service responses
- update login logic to expose reset requirement instead of blocking login
- adjust controller and service tests for new `AuthResponse` constructor

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684d80ae0a54832cb49e585c3dbafdf3