### PR TITLE
Add API to create tenant admin

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/AdminController.java
+++ b/src/main/java/com/myslotify/slotify/controller/AdminController.java
@@ -1,0 +1,26 @@
+package com.myslotify.slotify.controller;
+
+import com.myslotify.slotify.dto.CreateUserRequest;
+import com.myslotify.slotify.entity.Admin;
+import com.myslotify.slotify.service.AdminService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admins")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    public AdminController(AdminService adminService) {
+        this.adminService = adminService;
+    }
+
+    @PostMapping("/tenant")
+    public ResponseEntity<Admin> createTenantAdmin(@RequestBody CreateUserRequest request) {
+        return ResponseEntity.ok(adminService.createTenantAdmin(request));
+    }
+}

--- a/src/main/java/com/myslotify/slotify/service/AdminService.java
+++ b/src/main/java/com/myslotify/slotify/service/AdminService.java
@@ -1,0 +1,10 @@
+package com.myslotify.slotify.service;
+
+import com.myslotify.slotify.dto.CreateUserRequest;
+import com.myslotify.slotify.entity.Admin;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface AdminService {
+    Admin createTenantAdmin(CreateUserRequest request);
+}

--- a/src/main/java/com/myslotify/slotify/service/AdminServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AdminServiceImpl.java
@@ -1,0 +1,41 @@
+package com.myslotify.slotify.service;
+
+import com.myslotify.slotify.dto.CreateUserRequest;
+import com.myslotify.slotify.entity.Admin;
+import com.myslotify.slotify.entity.AdminRole;
+import com.myslotify.slotify.exception.BadRequestException;
+import com.myslotify.slotify.repository.AdminRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class AdminServiceImpl implements AdminService {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public AdminServiceImpl(AdminRepository adminRepository, PasswordEncoder passwordEncoder) {
+        this.adminRepository = adminRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public Admin createTenantAdmin(CreateUserRequest request) {
+        Optional<Admin> existing = adminRepository.findByEmail(request.getEmail());
+        if (existing.isPresent()) {
+            throw new BadRequestException("Admin already exists");
+        }
+
+        Admin admin = new Admin();
+        admin.setFirstName(request.getFirstName());
+        admin.setLastName(request.getLastName());
+        admin.setPhone(request.getPhone());
+        admin.setEmail(request.getEmail());
+        admin.setPassword(passwordEncoder.encode(request.getPassword()));
+        admin.setRole(AdminRole.TENANT_ADMIN);
+
+        return adminRepository.save(admin);
+    }
+}

--- a/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
@@ -68,8 +68,8 @@ public class UserServiceImpl implements UserService {
         user.setPhone(request.getPhone());
         user.setEmail(request.getEmail());
         user.setPassword(passwordEncoder.encode(request.getPassword()));
-        user.setRole(request.getRole());
-        user.setPasswordResetRequired(Role.EMPLOYEE.equals(request.getRole()));
+        user.setRole(Role.CUSTOMER);
+        user.setPasswordResetRequired(false);
 
         userRepository.save(user);
 

--- a/src/test/java/com/myslotify/slotify/controller/AdminControllerTest.java
+++ b/src/test/java/com/myslotify/slotify/controller/AdminControllerTest.java
@@ -1,0 +1,40 @@
+package com.myslotify.slotify.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.myslotify.slotify.dto.CreateUserRequest;
+import com.myslotify.slotify.entity.Admin;
+import com.myslotify.slotify.service.AdminService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AdminController.class)
+class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AdminService adminService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void createTenantAdminReturnsOk() throws Exception {
+        CreateUserRequest request = new CreateUserRequest();
+        Mockito.when(adminService.createTenantAdmin(Mockito.any())).thenReturn(new Admin());
+
+        mockMvc.perform(post("/api/admins/tenant")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/myslotify/slotify/service/AdminServiceImplTest.java
+++ b/src/test/java/com/myslotify/slotify/service/AdminServiceImplTest.java
@@ -1,0 +1,58 @@
+package com.myslotify.slotify.service;
+
+import com.myslotify.slotify.dto.CreateUserRequest;
+import com.myslotify.slotify.entity.Admin;
+import com.myslotify.slotify.entity.AdminRole;
+import com.myslotify.slotify.exception.BadRequestException;
+import com.myslotify.slotify.repository.AdminRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceImplTest {
+
+    @Mock
+    private AdminRepository adminRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AdminServiceImpl adminService;
+
+    @Test
+    void createsTenantAdmin() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.email = "admin@example.com";
+        request.password = "pass";
+        request.firstName = "A";
+        request.lastName = "B";
+        request.phone = "123";
+
+        when(adminRepository.findByEmail("admin@example.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("pass")).thenReturn("hash");
+        when(adminRepository.save(any(Admin.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Admin admin = adminService.createTenantAdmin(request);
+        assertEquals(AdminRole.TENANT_ADMIN, admin.getRole());
+        assertEquals("hash", admin.getPassword());
+    }
+
+    @Test
+    void throwsWhenAdminExists() {
+        CreateUserRequest request = new CreateUserRequest();
+        request.email = "admin@example.com";
+
+        when(adminRepository.findByEmail("admin@example.com")).thenReturn(Optional.of(new Admin()));
+
+        assertThrows(BadRequestException.class, () -> adminService.createTenantAdmin(request));
+    }
+}


### PR DESCRIPTION
## Summary
- add `AdminService` and `AdminServiceImpl`
- introduce `AdminController` for `/api/admins/tenant`
- modify `createUser` to always create customers
- add tests for new service and controller

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684d84694ef0832c96bb729114012cbf