### PR TITLE
Add tenant lookup by key API

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ If the subscription status is `ACTIVE`, only the tenant information is
 returned. When the status is `PENDING`, a new Stripe Checkout session is
 created and its `paymentUrl` is included in the response.
 
+Public clients can also fetch tenant details by key without authentication:
+
+```
+GET /api/tenants/key/{schemaName}
+```
+
 ## Activating a tenant
 
 Tenant admins can activate their tenant after payment is confirmed:

--- a/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
+++ b/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
                                 "/api/auth/**",
                                 "/v3/api-docs/**",
                                 "/swagger-ui.html",
-                                "/swagger-ui/**"
+                                "/swagger-ui/**",
+                                "/api/tenants/key/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/myslotify/slotify/controller/TenantController.java
+++ b/src/main/java/com/myslotify/slotify/controller/TenantController.java
@@ -32,6 +32,12 @@ public class TenantController {
         return ResponseEntity.ok(tenantService.getTenantById(id));
     }
 
+    @PreAuthorize("permitAll()")
+    @GetMapping("/key/{key}")
+    public ResponseEntity<Tenant> getTenantByKey(@PathVariable String key) {
+        return ResponseEntity.ok(tenantService.getTenantByKey(key));
+    }
+
     @PreAuthorize("hasRole('TENANT_ADMIN')")
     @PostMapping
     public ResponseEntity<TenantResponse> createTenant(@RequestBody TenantRequest request) {

--- a/src/main/java/com/myslotify/slotify/service/TenantService.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantService.java
@@ -36,4 +36,12 @@ public interface TenantService {
      * @return the updated tenant entity
      */
     Tenant activateTenant();
+
+    /**
+     * Retrieve tenant information by its unique key (schema name).
+     *
+     * @param key the tenant key
+     * @return the tenant entity
+     */
+    Tenant getTenantByKey(String key);
 }

--- a/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
@@ -170,6 +170,12 @@ public class TenantServiceImpl implements TenantService {
     }
 
     @Override
+    public Tenant getTenantByKey(String key) {
+        return tenantRepository.findBySchemaName(key)
+                .orElseThrow(() -> new NotFoundException("Tenant not found"));
+    }
+
+    @Override
     public void deleteTenant(UUID id) {
         tenantRepository.deleteById(id);
     }

--- a/src/test/java/com/myslotify/slotify/controller/TenantControllerTest.java
+++ b/src/test/java/com/myslotify/slotify/controller/TenantControllerTest.java
@@ -1,0 +1,31 @@
+package com.myslotify.slotify.controller;
+
+import com.myslotify.slotify.entity.Tenant;
+import com.myslotify.slotify.service.TenantService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TenantController.class)
+class TenantControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TenantService tenantService;
+
+    @Test
+    void getTenantByKeyReturnsOk() throws Exception {
+        Mockito.when(tenantService.getTenantByKey("tenant1")).thenReturn(new Tenant());
+
+        mockMvc.perform(get("/api/tenants/key/tenant1"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- expose an unauthenticated endpoint for retrieving tenant info by key
- permit requests to `/api/tenants/key/**`
- document the new endpoint
- test TenantController

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684d8bdc13f0832cb1f747cce05db04b