### PR TITLE
Add tenant update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,14 @@ POST /api/tenants/activate
 
 This sets the tenant's subscription status to `ACTIVE`, creates the schema and
 applies Liquibase migrations.
+
+## Updating tenant info
+
+Tenant admins can modify details about their tenant once activated:
+
+```
+PUT /api/tenants/me
+```
+
+The request body uses the same format as tenant creation and the updated
+tenant record is returned on success.

--- a/src/main/java/com/myslotify/slotify/controller/TenantController.java
+++ b/src/main/java/com/myslotify/slotify/controller/TenantController.java
@@ -4,6 +4,7 @@ import com.myslotify.slotify.dto.TenantRequest;
 import com.myslotify.slotify.dto.TenantResponse;
 import com.myslotify.slotify.entity.Tenant;
 import com.myslotify.slotify.service.TenantService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -42,6 +43,14 @@ public class TenantController {
     @GetMapping("/me")
     public ResponseEntity<TenantResponse> getCurrentTenant() {
         return ResponseEntity.ok(tenantService.getCurrentTenant());
+    }
+
+    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PutMapping("/me")
+    @Operation(summary = "Update current tenant information",
+            description = "Allows a tenant admin to modify the tenant profile")
+    public ResponseEntity<Tenant> updateTenant(@RequestBody TenantRequest request) {
+        return ResponseEntity.ok(tenantService.updateTenant(request));
     }
 
     @PreAuthorize("hasRole('ADMIN')")

--- a/src/main/java/com/myslotify/slotify/service/TenantService.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantService.java
@@ -13,6 +13,8 @@ public interface TenantService {
 
     TenantResponse createTenant(TenantRequest request);
 
+    Tenant updateTenant(TenantRequest request);
+
     List<Tenant> getAllTenants();
 
     Tenant getTenantById(UUID id);

--- a/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
@@ -136,6 +136,36 @@ public class TenantServiceImpl implements TenantService {
         return tenant;
     }
 
+    @Override
+    public Tenant updateTenant(TenantRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new BadRequestException("Missing authentication");
+        }
+
+        String email = authentication.getName();
+        Tenant tenant = tenantRepository.findByTenantAdminEmail(email)
+                .orElseThrow(() -> new NotFoundException("Tenant not found"));
+
+        tenant.setName(request.getName());
+        tenant.setDescription(request.getDescription());
+        tenant.setMotto(request.getMotto());
+        tenant.setAddress(request.getAddress());
+        tenant.setPhone(request.getPhone());
+        tenant.setTiktok(request.getTiktok());
+        tenant.setInstagram(request.getInstagram());
+        tenant.setTextColour(request.getTextColour());
+        tenant.setBackgroundColour(request.getBackgroundColour());
+        tenant.setBorderColour(request.getBorderColour());
+        tenant.setFont(request.getFont());
+        tenant.setLogo(request.getLogo());
+        tenant.setCoverPicture(request.getCoverPicture());
+        tenant.setUpdatedAt(LocalDateTime.now());
+
+        tenantRepository.save(tenant);
+        return tenant;
+    }
+
     private void createSchema(String schemaName) {
         if (!SCHEMA_PATTERN.matcher(schemaName).matches()) {
             throw new IllegalArgumentException("Invalid schema name");


### PR DESCRIPTION
## Summary
- allow tenant admin to update tenant info
- implement service method and controller route
- document update endpoint in README and add OpenAPI annotations

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684d8c99f970832c878666a39e31bd4a