### PR TITLE
Allow tenant admin endpoint without authentication

### DIFF
--- a/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
+++ b/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/swagger-ui.html",
                                 "/swagger-ui/**",
-                                "/api/tenants/key/**"
+                                "/api/tenants/key/**",
+                                "/api/admins/tenant"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## Summary
- permit `/api/admins/tenant` so it can be accessed without authentication

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684d95f042f4832cac5c0bb2ec4a5329