### PR TITLE
Add admin tenant activation and soft delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,19 @@ POST /api/tenants/activate
 This sets the tenant's subscription status to `ACTIVE`, creates the schema and
 applies Liquibase migrations.
 
+System administrators can also activate a specific tenant by id:
+
+```
+POST /api/tenants/{tenantId}/activate
+```
+
+This performs the same activation steps without relying on the tenant admin's
+authentication.
+
+Deleting a tenant via the admin API no longer removes the record. Instead the
+tenant's subscription status is set to `INACTIVE` so the data remains available
+for reactivation.
+
 ## Updating tenant info
 
 Tenant admins can modify details about their tenant once activated:

--- a/src/main/java/com/myslotify/slotify/controller/TenantController.java
+++ b/src/main/java/com/myslotify/slotify/controller/TenantController.java
@@ -66,6 +66,13 @@ public class TenantController {
         return ResponseEntity.noContent().build();
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/{id}/activate")
+    public ResponseEntity<Tenant> activateTenant(@PathVariable UUID id) {
+        Tenant tenant = tenantService.activateTenant(id);
+        return ResponseEntity.ok(tenant);
+    }
+
     @PreAuthorize("hasRole('TENANT_ADMIN')")
     @PostMapping("/activate")
     public ResponseEntity<Tenant> activateTenant() {

--- a/src/main/java/com/myslotify/slotify/service/TenantService.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantService.java
@@ -22,6 +22,15 @@ public interface TenantService {
     void deleteTenant(UUID id);
 
     /**
+     * Activate the tenant with the given id. Used by admins to manually
+     * enable a tenant without relying on the authenticated tenant admin.
+     *
+     * @param id the tenant identifier
+     * @return the activated tenant entity
+     */
+    Tenant activateTenant(UUID id);
+
+    /**
      * Fetch information for the tenant owned by the currently authenticated
      * TENANT_ADMIN. The tenant is resolved from the admin's user account.
      * If the subscription is pending, a new Stripe Checkout session is created


### PR DESCRIPTION
## Summary
- allow admins to activate tenants by ID
- mark tenants inactive instead of deleting
- document new admin activation endpoint and deletion behaviour

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684da3747708832caad5299ad5d3f5dd