### PR TITLE
Use tenant context

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ their subscription is still pending:
 GET /api/tenants/me
 ```
 
-The backend looks up the tenant using the authenticated admin's account.
-If the subscription status is `ACTIVE`, only the tenant information is
-returned. When the status is `PENDING`, a new Stripe Checkout session is
-created and its `paymentUrl` is included in the response.
+The backend resolves the tenant using the `X-Tenant-ID` header rather than the
+authenticated admin's account. If the subscription status is `ACTIVE`, only the
+tenant information is returned. When the status is `PENDING`, a new Stripe
+Checkout session is created and its `paymentUrl` is included in the response.
 
 Public clients can also fetch tenant details by key without authentication:
 

--- a/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
@@ -9,10 +9,11 @@ import com.myslotify.slotify.exception.NotFoundException;
 import com.myslotify.slotify.repository.TenantRepository;
 import jakarta.transaction.Transactional;
 import liquibase.integration.spring.SpringLiquibase;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import com.myslotify.slotify.util.TenantContext;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -87,13 +88,12 @@ public class TenantServiceImpl implements TenantService {
 
     @Override
     public TenantResponse getCurrentTenant() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null) {
-            throw new BadRequestException("Missing authentication");
+        String schema = TenantContext.getCurrentTenant();
+        if (schema == null) {
+            throw new BadRequestException("Missing tenant context");
         }
 
-        String email = authentication.getName();
-        Tenant tenant = tenantRepository.findByTenantAdminEmail(email)
+        Tenant tenant = tenantRepository.findBySchemaName(schema)
                 .orElseThrow(() -> new NotFoundException("Tenant not found"));
 
         if (tenant.getSubscriptionStatus() == SubscriptionStatus.ACTIVE) {
@@ -117,13 +117,12 @@ public class TenantServiceImpl implements TenantService {
 
     @Transactional
     public Tenant activateTenant() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null) {
-            throw new BadRequestException("Missing authentication");
+        String schema = TenantContext.getCurrentTenant();
+        if (schema == null) {
+            throw new BadRequestException("Missing tenant context");
         }
 
-        String email = authentication.getName();
-        Tenant tenant = tenantRepository.findByTenantAdminEmail(email)
+        Tenant tenant = tenantRepository.findBySchemaName(schema)
                 .orElseThrow(() -> new NotFoundException("Tenant not found"));
         tenant.setSubscriptionStatus(SubscriptionStatus.ACTIVE);
 
@@ -138,13 +137,12 @@ public class TenantServiceImpl implements TenantService {
 
     @Override
     public Tenant updateTenant(TenantRequest request) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null) {
-            throw new BadRequestException("Missing authentication");
+        String schema = TenantContext.getCurrentTenant();
+        if (schema == null) {
+            throw new BadRequestException("Missing tenant context");
         }
 
-        String email = authentication.getName();
-        Tenant tenant = tenantRepository.findByTenantAdminEmail(email)
+        Tenant tenant = tenantRepository.findBySchemaName(schema)
                 .orElseThrow(() -> new NotFoundException("Tenant not found"));
 
         tenant.setName(request.getName());

--- a/src/test/java/com/myslotify/slotify/service/TenantServiceImplTest.java
+++ b/src/test/java/com/myslotify/slotify/service/TenantServiceImplTest.java
@@ -5,8 +5,7 @@ import com.myslotify.slotify.entity.Tenant;
 import com.myslotify.slotify.exception.NotFoundException;
 import com.myslotify.slotify.repository.TenantRepository;
 import liquibase.integration.spring.SpringLiquibase;
-import org.springframework.security.authentication.TestingAuthenticationToken;
-import org.springframework.security.core.context.SecurityContextHolder;
+import com.myslotify.slotify.util.TenantContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,8 +44,7 @@ class TenantServiceImplTest {
     void setUp() throws Exception {
         when(dataSource.getConnection()).thenReturn(connection);
         when(connection.createStatement()).thenReturn(statement);
-        TestingAuthenticationToken auth = new TestingAuthenticationToken("admin@example.com", null);
-        SecurityContextHolder.getContext().setAuthentication(auth);
+        TenantContext.setCurrentTenant("demo_schema");
     }
 
     @Test
@@ -54,7 +52,7 @@ class TenantServiceImplTest {
         Tenant tenant = new Tenant();
         tenant.setSchemaName("demo_schema");
         tenant.setSubscriptionStatus(SubscriptionStatus.PENDING);
-        when(tenantRepository.findByTenantAdminEmail("admin@example.com"))
+        when(tenantRepository.findBySchemaName("demo_schema"))
                 .thenReturn(Optional.of(tenant));
 
         Tenant result = tenantService.activateTenant();
@@ -70,7 +68,7 @@ class TenantServiceImplTest {
 
     @Test
     void activateTenantThrowsWhenNotFound() {
-        when(tenantRepository.findByTenantAdminEmail("admin@example.com"))
+        when(tenantRepository.findBySchemaName("demo_schema"))
                 .thenReturn(Optional.empty());
         assertThrows(NotFoundException.class,
                 () -> tenantService.activateTenant());


### PR DESCRIPTION
## Summary
- rely on X-Tenant-ID context when looking up tenants
- update tenant activation tests
- document new tenant lookup mechanism

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684df5bd1e54832c9e32c91404e8d7ee