### PR TITLE
Allow employees and customers to view their profiles

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/UserController.java
+++ b/src/main/java/com/myslotify/slotify/controller/UserController.java
@@ -8,6 +8,7 @@ import com.myslotify.slotify.entity.User;
 import com.myslotify.slotify.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -29,10 +30,16 @@ public class UserController {
         return ResponseEntity.ok(userService.getAllEmployees());
     }
 
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasRole('TENANT_ADMIN') or (hasRole('EMPLOYEE') and #id == authentication.principal.id)")
     @GetMapping("/employee/{id}")
     public ResponseEntity<Employee> getEmployee(@PathVariable UUID id) {
         return ResponseEntity.ok(userService.getEmployee(id));
+    }
+
+    @PreAuthorize("hasRole('EMPLOYEE')")
+    @GetMapping("/employee/me")
+    public ResponseEntity<Employee> getCurrentEmployee(Authentication auth) {
+        return ResponseEntity.ok(userService.getCurrentEmployee(auth));
     }
 
     @PreAuthorize("hasRole('TENANT_ADMIN')")
@@ -54,10 +61,16 @@ public class UserController {
         return ResponseEntity.ok(userService.getAllUsers());
     }
 
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasRole('TENANT_ADMIN') or (hasRole('CUSTOMER') and #id == authentication.principal.id)")
     @GetMapping("/user/{id}")
     public ResponseEntity<User> getUser(@PathVariable UUID id) {
         return ResponseEntity.ok(userService.getUser(id));
+    }
+
+    @PreAuthorize("hasRole('CUSTOMER')")
+    @GetMapping("/user/me")
+    public ResponseEntity<User> getCurrentUser(Authentication auth) {
+        return ResponseEntity.ok(userService.getCurrentUser(auth));
     }
 
     @PreAuthorize("hasRole('USER')")

--- a/src/main/java/com/myslotify/slotify/service/UserService.java
+++ b/src/main/java/com/myslotify/slotify/service/UserService.java
@@ -6,6 +6,7 @@ import com.myslotify.slotify.dto.UpdateUserRequest;
 import com.myslotify.slotify.entity.Employee;
 import com.myslotify.slotify.entity.User;
 import org.springframework.stereotype.Service;
+import org.springframework.security.core.Authentication;
 
 import java.util.List;
 import java.util.UUID;
@@ -14,8 +15,10 @@ import java.util.UUID;
 public interface UserService {
     List<Employee> getAllEmployees();
     Employee getEmployee(UUID id);
+    Employee getCurrentEmployee(Authentication auth);
     List<User> getAllUsers();
     User getUser(UUID id);
+    User getCurrentUser(Authentication auth);
     AuthResponse createUser(CreateUserRequest request);
     Employee createEmployee(CreateUserRequest request);
     User updateUser(UUID id, UpdateUserRequest request);

--- a/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
@@ -11,6 +11,7 @@ import com.myslotify.slotify.exception.NotFoundException;
 import com.myslotify.slotify.repository.EmployeeRepository;
 import com.myslotify.slotify.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -47,12 +48,24 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new NotFoundException("Employee not found"));
     }
 
+    public Employee getCurrentEmployee(Authentication auth) {
+        String email = auth.getName();
+        return employeeRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundException("Employee not found"));
+    }
+
     public List<User> getAllUsers() {
         return userRepository.findAll();
     }
 
     public User getUser(UUID id) {
         return userRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("User not found"));
+    }
+
+    public User getCurrentUser(Authentication auth) {
+        String email = auth.getName();
+        return userRepository.findByEmail(email)
                 .orElseThrow(() -> new NotFoundException("User not found"));
     }
 


### PR DESCRIPTION
## Summary
- update `UserService` API to support fetching current user/employee
- implement new service methods in `UserServiceImpl`
- expose `/employee/me` and `/user/me` endpoints
- allow employees and customers to access their own records via `/employee/{id}` and `/user/{id}`

## Testing
- `./mvnw -q test` *(fails: could not resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684df9c5dac4832c9143840481c3d4f3