### PR TITLE
Store tenant images on filesystem

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/TenantController.java
+++ b/src/main/java/com/myslotify/slotify/controller/TenantController.java
@@ -4,6 +4,7 @@ import com.myslotify.slotify.dto.TenantRequest;
 import com.myslotify.slotify.dto.TenantResponse;
 import com.myslotify.slotify.entity.Tenant;
 import com.myslotify.slotify.service.TenantService;
+import org.springframework.http.MediaType;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -40,8 +41,8 @@ public class TenantController {
     }
 
     @PreAuthorize("hasRole('TENANT_ADMIN')")
-    @PostMapping
-    public ResponseEntity<TenantResponse> createTenant(@RequestBody TenantRequest request) {
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<TenantResponse> createTenant(@ModelAttribute TenantRequest request) {
         return ResponseEntity.ok(tenantService.createTenant(request));
     }
 
@@ -52,10 +53,10 @@ public class TenantController {
     }
 
     @PreAuthorize("hasRole('TENANT_ADMIN')")
-    @PutMapping("/me")
+    @PutMapping(value = "/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "Update current tenant information",
             description = "Allows a tenant admin to modify the tenant profile")
-    public ResponseEntity<Tenant> updateTenant(@RequestBody TenantRequest request) {
+    public ResponseEntity<Tenant> updateTenant(@ModelAttribute TenantRequest request) {
         return ResponseEntity.ok(tenantService.updateTenant(request));
     }
 

--- a/src/main/java/com/myslotify/slotify/dto/TenantRequest.java
+++ b/src/main/java/com/myslotify/slotify/dto/TenantRequest.java
@@ -1,6 +1,7 @@
 package com.myslotify.slotify.dto;
 
 import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 
@@ -22,6 +23,6 @@ public class TenantRequest {
     private String borderColour;
     private String font;
 
-    private byte[] logo;
-    private byte[] coverPicture;
+    private MultipartFile logo;
+    private MultipartFile coverPicture;
 }

--- a/src/main/java/com/myslotify/slotify/entity/Tenant.java
+++ b/src/main/java/com/myslotify/slotify/entity/Tenant.java
@@ -37,8 +37,9 @@ public class Tenant {
     private String borderColour;
     private String font;
 
-    @Lob
-    private byte[] logo;
-    @Lob
-    private byte[] coverPicture;
+    @Column(name = "logo_url")
+    private String logoUrl;
+
+    @Column(name = "cover_picture_url")
+    private String coverPictureUrl;
 }

--- a/src/main/java/com/myslotify/slotify/service/FileStorageService.java
+++ b/src/main/java/com/myslotify/slotify/service/FileStorageService.java
@@ -1,0 +1,44 @@
+package com.myslotify.slotify.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Service
+public class FileStorageService {
+
+    private final Path storageLocation;
+
+    public FileStorageService(@Value("${file.upload-dir:uploads}") String uploadDir) {
+        this.storageLocation = Paths.get(uploadDir).toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(this.storageLocation);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create upload directory", e);
+        }
+    }
+
+    public String store(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return null;
+        }
+        String originalFilename = StringUtils.cleanPath(file.getOriginalFilename());
+        String filename = UUID.randomUUID() + "_" + originalFilename;
+        Path target = this.storageLocation.resolve(filename);
+        try (InputStream inputStream = file.getInputStream()) {
+            Files.copy(inputStream, target, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to store file", e);
+        }
+        return target.toString();
+    }
+}

--- a/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
@@ -30,17 +30,20 @@ public class TenantServiceImpl implements TenantService {
     private final TenantRepository tenantRepository;
     private final SpringLiquibase springLiquibase;
     private final StripeService stripeService;
+    private final FileStorageService fileStorageService;
 
     private static final Pattern SCHEMA_PATTERN = Pattern.compile("[A-Za-z0-9_]+");
 
     public TenantServiceImpl(DataSource dataSource,
                              TenantRepository tenantRepository,
                              SpringLiquibase springLiquibase,
-                             StripeService stripeService) {
+                             StripeService stripeService,
+                             FileStorageService fileStorageService) {
         this.dataSource = dataSource;
         this.tenantRepository = tenantRepository;
         this.springLiquibase = springLiquibase;
         this.stripeService = stripeService;
+        this.fileStorageService = fileStorageService;
     }
 
     @Value("${stripe.success.url}")
@@ -67,8 +70,14 @@ public class TenantServiceImpl implements TenantService {
         tenant.setBackgroundColour(request.getBackgroundColour());
         tenant.setBorderColour(request.getBorderColour());
         tenant.setFont(request.getFont());
-        tenant.setLogo(request.getLogo());
-        tenant.setCoverPicture(request.getCoverPicture());
+        if (request.getLogo() != null && !request.getLogo().isEmpty()) {
+            String logoPath = fileStorageService.store(request.getLogo());
+            tenant.setLogoUrl(logoPath);
+        }
+        if (request.getCoverPicture() != null && !request.getCoverPicture().isEmpty()) {
+            String coverPath = fileStorageService.store(request.getCoverPicture());
+            tenant.setCoverPictureUrl(coverPath);
+        }
         tenant.setCreatedAt(LocalDateTime.now());
         tenant.setSubscriptionStatus(SubscriptionStatus.PENDING);
 
@@ -156,8 +165,14 @@ public class TenantServiceImpl implements TenantService {
         tenant.setBackgroundColour(request.getBackgroundColour());
         tenant.setBorderColour(request.getBorderColour());
         tenant.setFont(request.getFont());
-        tenant.setLogo(request.getLogo());
-        tenant.setCoverPicture(request.getCoverPicture());
+        if (request.getLogo() != null && !request.getLogo().isEmpty()) {
+            String logoPath = fileStorageService.store(request.getLogo());
+            tenant.setLogoUrl(logoPath);
+        }
+        if (request.getCoverPicture() != null && !request.getCoverPicture().isEmpty()) {
+            String coverPath = fileStorageService.store(request.getCoverPicture());
+            tenant.setCoverPictureUrl(coverPath);
+        }
         tenant.setUpdatedAt(LocalDateTime.now());
 
         tenantRepository.save(tenant);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,3 +44,5 @@ spring.mail.properties.mail.smtp.starttls.required=true
 twilio.account-sid=AC35f3bd85726d01221d30190485ebb938
 twilio.auth-token=d3675c1bec01287375afcad5f4f8d6cf
 twilio.from-phone=+381600162383
+# File upload path
+file.upload-dir=uploads

--- a/src/main/resources/db/changelog/db.changelog-system.xml
+++ b/src/main/resources/db/changelog/db.changelog-system.xml
@@ -33,8 +33,8 @@
       <column name="background_colour" type="VARCHAR(255)"/>
       <column name="border_colour" type="VARCHAR(255)"/>
       <column name="font" type="VARCHAR(255)"/>
-      <column name="logo" type="BYTEA"/>
-      <column name="cover_picture" type="BYTEA"/>
+      <column name="logo_url" type="VARCHAR(512)"/>
+      <column name="cover_picture_url" type="VARCHAR(512)"/>
     </createTable>
   </changeSet>
   <changeSet id="create-admin-table" author="nikola">

--- a/src/test/java/com/myslotify/slotify/service/TenantServiceImplTest.java
+++ b/src/test/java/com/myslotify/slotify/service/TenantServiceImplTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.myslotify.slotify.service.FileStorageService;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -32,6 +33,8 @@ class TenantServiceImplTest {
     private SpringLiquibase springLiquibase;
     @Mock
     private StripeService stripeService;
+    @Mock
+    private FileStorageService fileStorageService;
     @Mock
     private Connection connection;
     @Mock


### PR DESCRIPTION
## Summary
- update `Tenant` entity to store URLs for logo and cover pictures
- modify liquibase changelog for new columns
- allow tenant endpoints to accept multipart form data
- store uploaded images using `FileStorageService`
- update application properties with upload directory
- adjust service tests for new dependency

## Testing
- `./mvnw -q -Dtest=TenantServiceImplTest -DfailIfNoTests=false test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684f43c11158832cbcf65d364be717e3