### PR TITLE
Fix tenant admin reference

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/Tenant.java
+++ b/src/main/java/com/myslotify/slotify/entity/Tenant.java
@@ -3,6 +3,7 @@ package com.myslotify.slotify.entity;
 import jakarta.persistence.*;
 import lombok.Data;
 
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -22,8 +23,8 @@ public class Tenant {
     @Column(nullable = false)
     private SubscriptionStatus subscriptionStatus;
     @OneToOne
-    @JoinColumn(name = "user_id")
-    private User tenantAdmin;
+    @JoinColumn(name = "admin_id")
+    private Admin tenantAdmin;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 

--- a/src/main/resources/db/changelog/db.changelog-system.xml
+++ b/src/main/resources/db/changelog/db.changelog-system.xml
@@ -17,7 +17,7 @@
       <column name="schema_name" type="VARCHAR(255)" >
         <constraints unique="true" nullable="false"/>
       </column>
-      <column name="user_id" type="UUID"/>
+      <column name="admin_id" type="UUID"/>
       <column name="created_at" type="TIMESTAMP">
         <constraints nullable="false"/>
       </column>


### PR DESCRIPTION
## Summary
- use `Admin` instead of `User` for `tenantAdmin`
- rename column to `admin_id` in Liquibase changelog

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684f4630fbe0832c8ae0d65faf829301