### PR TITLE
Allow tenant admin login without tenant

### DIFF
--- a/src/main/java/com/myslotify/slotify/dto/AuthResponse.java
+++ b/src/main/java/com/myslotify/slotify/dto/AuthResponse.java
@@ -1,14 +1,27 @@
 package com.myslotify.slotify.dto;
 
 import com.myslotify.slotify.entity.BaseAccount;
-import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
+@NoArgsConstructor
 public class AuthResponse {
     public String message;
     public String token;
     public BaseAccount account;
     public boolean passwordResetRequired;
+    public Boolean tenantExists;
+
+    public AuthResponse(String message, String token, BaseAccount account, boolean passwordResetRequired) {
+        this(message, token, account, passwordResetRequired, null);
+    }
+
+    public AuthResponse(String message, String token, BaseAccount account, boolean passwordResetRequired, Boolean tenantExists) {
+        this.message = message;
+        this.token = token;
+        this.account = account;
+        this.passwordResetRequired = passwordResetRequired;
+        this.tenantExists = tenantExists;
+    }
 }


### PR DESCRIPTION
## Summary
- permit TENANT_ADMIN to log in even if no tenant exists
- include new `tenantExists` flag in authentication responses
- update tests for new behaviour

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684ffbeac9e4832c8e202baaf4f1cfc2