### PR TITLE
Add interface for FileStorageService

### DIFF
--- a/src/main/java/com/myslotify/slotify/service/FileStorageService.java
+++ b/src/main/java/com/myslotify/slotify/service/FileStorageService.java
@@ -1,44 +1,9 @@
 package com.myslotify.slotify.service;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
-import java.util.UUID;
-
 @Service
-public class FileStorageService {
-
-    private final Path storageLocation;
-
-    public FileStorageService(@Value("${file.upload-dir:uploads}") String uploadDir) {
-        this.storageLocation = Paths.get(uploadDir).toAbsolutePath().normalize();
-        try {
-            Files.createDirectories(this.storageLocation);
-        } catch (IOException e) {
-            throw new RuntimeException("Could not create upload directory", e);
-        }
-    }
-
-    public String store(MultipartFile file) {
-        if (file == null || file.isEmpty()) {
-            return null;
-        }
-        String originalFilename = StringUtils.cleanPath(file.getOriginalFilename());
-        String filename = UUID.randomUUID() + "_" + originalFilename;
-        Path target = this.storageLocation.resolve(filename);
-        try (InputStream inputStream = file.getInputStream()) {
-            Files.copy(inputStream, target, StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to store file", e);
-        }
-        return target.toString();
-    }
+public interface FileStorageService {
+    String store(MultipartFile file);
 }

--- a/src/main/java/com/myslotify/slotify/service/FileStorageServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/FileStorageServiceImpl.java
@@ -1,0 +1,45 @@
+package com.myslotify.slotify.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Service
+public class FileStorageServiceImpl implements FileStorageService {
+
+    private final Path storageLocation;
+
+    public FileStorageServiceImpl(@Value("${file.upload-dir:uploads}") String uploadDir) {
+        this.storageLocation = Paths.get(uploadDir).toAbsolutePath().normalize();
+        try {
+            Files.createDirectories(this.storageLocation);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create upload directory", e);
+        }
+    }
+
+    @Override
+    public String store(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return null;
+        }
+        String originalFilename = StringUtils.cleanPath(file.getOriginalFilename());
+        String filename = UUID.randomUUID() + "_" + originalFilename;
+        Path target = this.storageLocation.resolve(filename);
+        try (InputStream inputStream = file.getInputStream()) {
+            Files.copy(inputStream, target, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to store file", e);
+        }
+        return target.toString();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `FileStorageService` interface
- rename existing file storage class to `FileStorageServiceImpl`
- implement the interface in the renamed class

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68505fce7850832ca6a25534f8a61281