### PR TITLE
Remove updatedAt field

### DIFF
--- a/src/main/java/com/myslotify/slotify/dto/TenantRequest.java
+++ b/src/main/java/com/myslotify/slotify/dto/TenantRequest.java
@@ -11,7 +11,6 @@ public class TenantRequest {
     private String schemaName;
     private String description;
     private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
     private String motto;
     private String address;

--- a/src/main/java/com/myslotify/slotify/entity/Tenant.java
+++ b/src/main/java/com/myslotify/slotify/entity/Tenant.java
@@ -31,9 +31,6 @@ public class Tenant {
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
-
     @Column(name = "motto")
     private String motto;
 

--- a/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
@@ -173,7 +173,6 @@ public class TenantServiceImpl implements TenantService {
             String coverPath = fileStorageService.store(request.getCoverPicture());
             tenant.setCoverPictureUrl(coverPath);
         }
-        tenant.setUpdatedAt(LocalDateTime.now());
 
         tenantRepository.save(tenant);
         return tenant;

--- a/src/main/resources/db/changelog/db.changelog-system.xml
+++ b/src/main/resources/db/changelog/db.changelog-system.xml
@@ -21,9 +21,6 @@
       <column name="created_at" type="TIMESTAMP">
         <constraints nullable="false"/>
       </column>
-      <column name="updated_at" type="TIMESTAMP">
-        <constraints nullable="false"/>
-      </column>
       <column name="motto" type="VARCHAR(255)"/>
       <column name="address" type="VARCHAR(255)"/>
       <column name="phone" type="VARCHAR(255)"/>


### PR DESCRIPTION
## Summary
- remove `updatedAt` column from Liquibase changelog
- drop `updatedAt` property from `Tenant` entity and `TenantRequest`
- stop setting `updatedAt` in `TenantServiceImpl`
- tidy up spacing after field removal

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851d15d5f40832ca01b29fa8bba4a38