### PR TITLE
Return JWT after tenant admin creation

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/AdminController.java
+++ b/src/main/java/com/myslotify/slotify/controller/AdminController.java
@@ -1,7 +1,7 @@
 package com.myslotify.slotify.controller;
 
+import com.myslotify.slotify.dto.AuthResponse;
 import com.myslotify.slotify.dto.CreateUserRequest;
-import com.myslotify.slotify.entity.Admin;
 import com.myslotify.slotify.service.AdminService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,7 +20,7 @@ public class AdminController {
     }
 
     @PostMapping("/tenant")
-    public ResponseEntity<Admin> createTenantAdmin(@RequestBody CreateUserRequest request) {
+    public ResponseEntity<AuthResponse> createTenantAdmin(@RequestBody CreateUserRequest request) {
         return ResponseEntity.ok(adminService.createTenantAdmin(request));
     }
 }

--- a/src/main/java/com/myslotify/slotify/service/AdminService.java
+++ b/src/main/java/com/myslotify/slotify/service/AdminService.java
@@ -1,10 +1,10 @@
 package com.myslotify.slotify.service;
 
+import com.myslotify.slotify.dto.AuthResponse;
 import com.myslotify.slotify.dto.CreateUserRequest;
-import com.myslotify.slotify.entity.Admin;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface AdminService {
-    Admin createTenantAdmin(CreateUserRequest request);
+    AuthResponse createTenantAdmin(CreateUserRequest request);
 }

--- a/src/test/java/com/myslotify/slotify/controller/AdminControllerTest.java
+++ b/src/test/java/com/myslotify/slotify/controller/AdminControllerTest.java
@@ -1,6 +1,7 @@
 package com.myslotify.slotify.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.myslotify.slotify.dto.AuthResponse;
 import com.myslotify.slotify.dto.CreateUserRequest;
 import com.myslotify.slotify.entity.Admin;
 import com.myslotify.slotify.service.AdminService;
@@ -30,7 +31,8 @@ class AdminControllerTest {
     @Test
     void createTenantAdminReturnsOk() throws Exception {
         CreateUserRequest request = new CreateUserRequest();
-        Mockito.when(adminService.createTenantAdmin(Mockito.any())).thenReturn(new Admin());
+        Mockito.when(adminService.createTenantAdmin(Mockito.any()))
+                .thenReturn(new AuthResponse("ok", "token", new Admin(), false));
 
         mockMvc.perform(post("/api/admins/tenant")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/myslotify/slotify/service/AdminServiceImplTest.java
+++ b/src/test/java/com/myslotify/slotify/service/AdminServiceImplTest.java
@@ -1,10 +1,12 @@
 package com.myslotify.slotify.service;
 
+import com.myslotify.slotify.dto.AuthResponse;
 import com.myslotify.slotify.dto.CreateUserRequest;
 import com.myslotify.slotify.entity.Admin;
 import com.myslotify.slotify.entity.AdminRole;
 import com.myslotify.slotify.exception.BadRequestException;
 import com.myslotify.slotify.repository.AdminRepository;
+import com.myslotify.slotify.service.JwtService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,6 +26,8 @@ class AdminServiceImplTest {
     private AdminRepository adminRepository;
     @Mock
     private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtService jwtService;
 
     @InjectMocks
     private AdminServiceImpl adminService;
@@ -40,10 +44,13 @@ class AdminServiceImplTest {
         when(adminRepository.findByEmail("admin@example.com")).thenReturn(Optional.empty());
         when(passwordEncoder.encode("pass")).thenReturn("hash");
         when(adminRepository.save(any(Admin.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(jwtService.generateToken(any(Admin.class))).thenReturn("token");
 
-        Admin admin = adminService.createTenantAdmin(request);
+        AuthResponse response = adminService.createTenantAdmin(request);
+        Admin admin = (Admin) response.getAccount();
         assertEquals(AdminRole.TENANT_ADMIN, admin.getRole());
         assertEquals("hash", admin.getPassword());
+        assertEquals("token", response.getToken());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- return JWT when creating tenant admins so they log in automatically
- adjust AdminController and services to deliver AuthResponse
- update related unit tests

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6851d53c1be4832c86c43d8bbadf1478