### PR TITLE
Add per-tenant Stripe success URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Several settings can be provided either via environment variables or by editing 
 - `STRIPE_API_SECRET` (`stripe.api.secret`)
 - `STRIPE_API_PUBLIC` (`stripe.api.public`)
 - `STRIPE_PRICE_ID` (`stripe.price.id`)
-- `STRIPE_SUCCESS_URL` (`stripe.success.url`)
+- `STRIPE_SUCCESS_URL` (`stripe.success.url`) base address used to construct the Stripe success URL as `STRIPE_SUCCESS_URL` + `/tenant/{schemaName}/form`
 - `STRIPE_CANCEL_URL` (`stripe.cancel.url`)
 - `DB_URL` (`spring.datasource.url`)
 - `DB_USERNAME` (`spring.datasource.username`)

--- a/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
@@ -47,7 +47,7 @@ public class TenantServiceImpl implements TenantService {
     }
 
     @Value("${stripe.success.url}")
-    private String successUrl;
+    private String successUrlBase;
 
     @Value("${stripe.cancel.url}")
     private String cancelUrl;
@@ -86,6 +86,7 @@ public class TenantServiceImpl implements TenantService {
         String sessionUrl = null;
         try {
             if (email != null) {
+                String successUrl = String.format("%s/tenant/%s/form", successUrlBase, tenant.getSchemaName());
                 sessionUrl = stripeService.createSubscriptionSession(email, successUrl, cancelUrl);
             }
         } catch (Exception e) {
@@ -115,6 +116,7 @@ public class TenantServiceImpl implements TenantService {
 
         String sessionUrl;
         try {
+            String successUrl = String.format("%s/tenant/%s/form", successUrlBase, tenant.getSchemaName());
             sessionUrl = stripeService.createSubscriptionSession(
                     tenant.getTenantAdmin().getEmail(), successUrl, cancelUrl);
         } catch (Exception e) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,7 +27,7 @@ app.jwt.secret=gq1HrVakbKbatpW4n+TnYRUS5g/S1TW6FILNWdpe5PqlBP73yonr8sQdpykIzrg0a
 stripe.api.secret=sk_test_51RVDWmFwBZdFT9hud9lKRvQpgWmGXyb9nReYyLN2QUhCiFlZKk9oEfcX0JfZEiNsCvXLIL4kpxTvkchWAGHwuwzJ00PQwmonF2
 stripe.api.public=pk_test_51RVDWmFwBZdFT9hu8AITcVGzwHFSLgekgO23hJYuw80nxNS2c9RhSn564YUrWUKMx4usHwCLLvZzgaVTEgPoVBaS00oj1hpx7R
 stripe.price.id=price_1RVDcqFwBZdFT9hucEWUww73
-stripe.success.url=http://localhost:8080/payment/success
+stripe.success.url=http://localhost:3000
 stripe.cancel.url=http://localhost:8080/payment/cancel
 
 # Mail configuration


### PR DESCRIPTION
## Summary
- build Stripe success URLs using the tenant's schema name
- clarify STRIPE_SUCCESS_URL use in README
- update example application properties

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851d8c8dc4c832ca55bcb95e3e68fc8