### PR TITLE
Fix retrieving email when creating tenant

### DIFF
--- a/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
@@ -6,6 +6,7 @@ import com.myslotify.slotify.exception.NotFoundException;
 import com.myslotify.slotify.exception.UnauthorizedException;
 import com.myslotify.slotify.repository.*;
 import com.myslotify.slotify.util.TenantContext;
+import com.myslotify.slotify.util.SecurityUtil;
 import org.springframework.security.core.Authentication;
 import org.springframework.scheduling.annotation.Scheduled;
 
@@ -52,13 +53,13 @@ public class AppointmentServiceImpl implements AppointmentService {
     }
 
     private User getCurrentUser(Authentication auth) {
-        String email = auth.getName();
+        String email = SecurityUtil.extractEmail(auth);
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new NotFoundException("User not found"));
     }
 
     private Employee getCurrentEmployee(Authentication auth) {
-        String email = auth.getName();
+        String email = SecurityUtil.extractEmail(auth);
         return employeeRepository.findByEmail(email)
                 .orElseThrow(() -> new NotFoundException("Employee not found"));
     }

--- a/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
@@ -9,6 +9,7 @@ import com.myslotify.slotify.repository.EmployeeAvailabilityRepository;
 import com.myslotify.slotify.repository.EmployeeRepository;
 import com.myslotify.slotify.repository.TimeSlotRepository;
 import com.myslotify.slotify.repository.ServiceRepository;
+import com.myslotify.slotify.util.SecurityUtil;
 import org.springframework.security.core.Authentication;
 
 import java.time.LocalDate;
@@ -34,7 +35,7 @@ public class AvailabilityServiceImpl implements AvailabilityService {
     }
 
     private Employee getCurrentEmployee(Authentication authentication) {
-        String email = authentication.getName();
+        String email = SecurityUtil.extractEmail(authentication);
         return employeeRepository.findByEmail(email)
                 .orElseThrow(() -> new NotFoundException("Employee not found"));
     }

--- a/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import com.myslotify.slotify.util.SecurityUtil;
 import com.myslotify.slotify.util.TenantContext;
 
 import javax.sql.DataSource;
@@ -55,7 +56,7 @@ public class TenantServiceImpl implements TenantService {
     @Override
     public TenantResponse createTenant(TenantRequest request) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String email = authentication != null ? authentication.getName() : null;
+        String email = SecurityUtil.extractEmail(authentication);
 
         Tenant tenant = new Tenant();
         tenant.setName(request.getName());

--- a/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/UserServiceImpl.java
@@ -12,6 +12,7 @@ import com.myslotify.slotify.repository.EmployeeRepository;
 import com.myslotify.slotify.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.core.Authentication;
+import com.myslotify.slotify.util.SecurityUtil;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -49,7 +50,7 @@ public class UserServiceImpl implements UserService {
     }
 
     public Employee getCurrentEmployee(Authentication auth) {
-        String email = auth.getName();
+        String email = SecurityUtil.extractEmail(auth);
         return employeeRepository.findByEmail(email)
                 .orElseThrow(() -> new NotFoundException("Employee not found"));
     }
@@ -64,7 +65,7 @@ public class UserServiceImpl implements UserService {
     }
 
     public User getCurrentUser(Authentication auth) {
-        String email = auth.getName();
+        String email = SecurityUtil.extractEmail(auth);
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new NotFoundException("User not found"));
     }

--- a/src/main/java/com/myslotify/slotify/util/SecurityUtil.java
+++ b/src/main/java/com/myslotify/slotify/util/SecurityUtil.java
@@ -1,0 +1,28 @@
+package com.myslotify.slotify.util;
+
+import com.myslotify.slotify.entity.Admin;
+import com.myslotify.slotify.entity.User;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public final class SecurityUtil {
+    private SecurityUtil() {}
+
+    public static String extractEmail(Authentication authentication) {
+        if (authentication == null) {
+            return null;
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof Admin admin) {
+            return admin.getEmail();
+        } else if (principal instanceof User user) {
+            return user.getEmail();
+        } else if (principal instanceof UserDetails userDetails) {
+            return userDetails.getUsername();
+        } else if (principal instanceof String str) {
+            return str;
+        }
+        return authentication.getName();
+    }
+}


### PR DESCRIPTION
## Summary
- ensure correct logged in email is used when creating tenants
- extract email helper to `SecurityUtil`
- reuse helper in appointment, availability and user services

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Non-resolvable parent POM)*
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851df0a37f0832c9c63c138f7ff1da5