### PR TITLE
Fix tenant admin being unset

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/Tenant.java
+++ b/src/main/java/com/myslotify/slotify/entity/Tenant.java
@@ -24,8 +24,8 @@ public class Tenant {
     @Column(name = "subscription_status", nullable = false)
     private SubscriptionStatus subscriptionStatus;
   
-    @OneToOne
-    @JoinColumn(name = "admin_id")
+    @OneToOne(optional = false)
+    @JoinColumn(name = "admin_id", nullable = false)
     private Admin tenantAdmin;
 
     @Column(name = "created_at")

--- a/src/main/resources/db/changelog/db.changelog-system.xml
+++ b/src/main/resources/db/changelog/db.changelog-system.xml
@@ -17,7 +17,9 @@
       <column name="schema_name" type="VARCHAR(255)" >
         <constraints unique="true" nullable="false"/>
       </column>
-      <column name="admin_id" type="UUID"/>
+      <column name="admin_id" type="UUID">
+        <constraints nullable="false"/>
+      </column>
       <column name="created_at" type="TIMESTAMP">
         <constraints nullable="false"/>
       </column>

--- a/src/test/java/com/myslotify/slotify/service/TenantServiceImplTest.java
+++ b/src/test/java/com/myslotify/slotify/service/TenantServiceImplTest.java
@@ -4,6 +4,7 @@ import com.myslotify.slotify.entity.SubscriptionStatus;
 import com.myslotify.slotify.entity.Tenant;
 import com.myslotify.slotify.exception.NotFoundException;
 import com.myslotify.slotify.repository.TenantRepository;
+import com.myslotify.slotify.repository.AdminRepository;
 import liquibase.integration.spring.SpringLiquibase;
 import com.myslotify.slotify.util.TenantContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +30,8 @@ class TenantServiceImplTest {
     private DataSource dataSource;
     @Mock
     private TenantRepository tenantRepository;
+    @Mock
+    private AdminRepository adminRepository;
     @Mock
     private SpringLiquibase springLiquibase;
     @Mock


### PR DESCRIPTION
## Summary
- enforce not-null tenant admin relationship
- assign tenant admin when creating a tenant
- update Liquibase changelog for new constraint
- adjust tests for new dependency

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685463886398832c996fb2fdb6810de6