### PR TITLE
Ensure system schema and admin table exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,8 @@ SPRING_DATASOURCE_PASSWORD=secret
 SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.postgresql.Driver
 ```
 
-Before running the application for the first time, create the `system` schema.
-Liquibase will load its tables into this schema:
-
-```sql
-CREATE SCHEMA system;
-```
+Liquibase automatically creates the `system` schema on first run and loads the
+`tenant` and `admin` tables into it.
 
 ## Environment variables
 

--- a/src/main/java/com/myslotify/slotify/entity/Admin.java
+++ b/src/main/java/com/myslotify/slotify/entity/Admin.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Entity
-@Table(name = "admin")
+@Table(name = "admin", schema = "system")
 @Data
 @EqualsAndHashCode(callSuper = true)
 @AttributeOverride(name = "id", column = @Column(name = "admin_id"))

--- a/src/main/resources/db/changelog/db.changelog-system.xml
+++ b/src/main/resources/db/changelog/db.changelog-system.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" ?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+  <changeSet id="create-system-schema" author="codex">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <schemaExists schemaName="system"/>
+      </not>
+    </preConditions>
+    <createSchema schemaName="system"/>
+  </changeSet>
   <changeSet id="create-tenant-table" author="nikola">
     <createTable tableName="tenant" schemaName="system">
       <column name="tenant_id" type="UUID">


### PR DESCRIPTION
## Summary
- map `Admin` entity to `system` schema
- create system schema automatically in Liquibase
- update docs that Liquibase creates the `system` schema on first run

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68546e537950832cb41058a8617a781c