### PR TITLE
Fix Liquibase XSD references

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
     <include file="classpath:db/changelog/db.changelog-system.xml"/>
 

--- a/src/main/resources/db/changelog/db.changelog-system.xml
+++ b/src/main/resources/db/changelog/db.changelog-system.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
   <changeSet id="create-system-schema" author="codex">
     <preConditions onFail="MARK_RAN">
       <not>

--- a/src/main/resources/db/changelog/db.changelog-tenant.xml
+++ b/src/main/resources/db/changelog/db.changelog-tenant.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
   <changeSet id="init-tenant-schema" author="nikola">
     <createTable tableName="user">
       <column name="user_id" type="UUID">


### PR DESCRIPTION
## Summary
- update Liquibase changelog XML files to use `dbchangelog-latest.xsd`

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM due to network access)*

------
https://chatgpt.com/codex/tasks/task_e_68547225d644832c81139f15e791642e