### PR TITLE
Fix Liquibase precondition

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-system.xml
+++ b/src/main/resources/db/changelog/db.changelog-system.xml
@@ -3,7 +3,9 @@
   <changeSet id="create-system-schema" author="codex">
     <preConditions onFail="MARK_RAN">
       <not>
-        <schemaExists schemaName="system"/>
+        <sqlCheck expectedResult="0">
+          SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = 'system'
+        </sqlCheck>
       </not>
     </preConditions>
     <createSchema schemaName="system"/>


### PR DESCRIPTION
## Summary
- fix liquibase precondition using sqlCheck

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685473a88eac832c9343b4787c2b5a7a