### PR TITLE
Revert automatic creation of system schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ SPRING_DATASOURCE_PASSWORD=secret
 SPRING_DATASOURCE_DRIVER_CLASS_NAME=org.postgresql.Driver
 ```
 
-Liquibase automatically creates the `system` schema on first run and loads the
-`tenant` and `admin` tables into it.
+Before running the application for the first time, create the `system` schema.
+Liquibase will load its tables into this schema:
+
+```sql
+CREATE SCHEMA system;
+```
 
 ## Environment variables
 

--- a/src/main/resources/db/changelog/db.changelog-system.xml
+++ b/src/main/resources/db/changelog/db.changelog-system.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" ?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
-  <changeSet id="create-system-schema" author="codex">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <sqlCheck expectedResult="0">
-          SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = 'system'
-        </sqlCheck>
-      </not>
-    </preConditions>
-    <createSchema schemaName="system"/>
-  </changeSet>
   <changeSet id="create-tenant-table" author="nikola">
     <createTable tableName="tenant" schemaName="system">
       <column name="tenant_id" type="UUID">


### PR DESCRIPTION
## Summary
- remove Liquibase change set that created the `system` schema
- update README to instruct manual schema creation

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685475d198b0832ca6c42fe6fcff7459