### PR TITLE
Fix employee mapping

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/Employee.java
+++ b/src/main/java/com/myslotify/slotify/entity/Employee.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Table(name = "employee")
 @Data
 @EqualsAndHashCode(callSuper = true)
+@AttributeOverride(name = "id", column = @Column(name = "employee_id"))
 @PrimaryKeyJoinColumn(name = "employee_id", referencedColumnName = "user_id")
 public class Employee extends User {
 


### PR DESCRIPTION
## Summary
- override id mapping for Employee to map to `employee_id`

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685494c03a28832c93a290fdbc8faf23