### PR TITLE
Show tenant id in log output

### DIFF
--- a/src/main/java/com/myslotify/slotify/filter/TenantFilter.java
+++ b/src/main/java/com/myslotify/slotify/filter/TenantFilter.java
@@ -1,6 +1,7 @@
 package com.myslotify.slotify.filter;
 
 import com.myslotify.slotify.util.TenantContext;
+import org.slf4j.MDC;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -19,11 +20,13 @@ public class TenantFilter extends OncePerRequestFilter {
         String tenantId = request.getHeader("X-Tenant-ID"); // Pass tenant identifier in a header
         if (tenantId != null) {
             TenantContext.setCurrentTenant(tenantId);
+            MDC.put("tenant", tenantId);
         }
         try {
             filterChain.doFilter(request, response);
         } finally {
             TenantContext.clear();
+            MDC.remove("tenant");
         }
     }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <property name="CONSOLE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [tenant=%X{tenant}] - %msg%n"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- add MDC support in `TenantFilter`
- configure Logback console pattern to print `[tenant]`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6854916f5e1c832cb8713ea0bd4c9fd1