### PR TITLE
Enable colored logging

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -46,3 +46,6 @@ twilio.auth-token=d3675c1bec01287375afcad5f4f8d6cf
 twilio.from-phone=+381600162383
 # File upload path
 file.upload-dir=uploads
+
+# Always enable ANSI colors in logs
+spring.output.ansi.enabled=ALWAYS

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
-    <property name="CONSOLE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [tenant=%X{tenant}] - %msg%n"/>
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %clr([%thread]){faint} %highlight(%-5level) %clr(%logger{36}){cyan} %clr([tenant=%X{tenant}]){magenta} - %msg%n"/>
     <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
     <root level="INFO">
         <appender-ref ref="CONSOLE" />


### PR DESCRIPTION
## Summary
- enhance logback pattern for colored output
- force ANSI color output via application.properties

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM because repo.maven.apache.org is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68549ee55540832cba5624eed9b3df29