### PR TITLE
Fix missing schema error for appointment reminders

### DIFF
--- a/src/main/java/com/myslotify/slotify/repository/TenantRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/TenantRepository.java
@@ -1,9 +1,11 @@
 package com.myslotify.slotify.repository;
 
 import com.myslotify.slotify.entity.Tenant;
+import com.myslotify.slotify.entity.SubscriptionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -14,4 +16,6 @@ public interface TenantRepository extends JpaRepository<Tenant, UUID> {
     Optional<Tenant> findBySchemaName(String schemaName);
 
     Optional<Tenant> findByTenantAdminEmail(String email);
+
+    List<Tenant> findAllBySubscriptionStatus(SubscriptionStatus subscriptionStatus);
 }

--- a/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
@@ -183,7 +183,7 @@ public class AppointmentServiceImpl implements AppointmentService {
     @Scheduled(cron = "0 0 * * * *")
     public void sendRemindersForUpcomingAppointments() {
         logger.info("Sending appointment reminders for all tenants");
-        List<Tenant> tenants = tenantRepository.findAll();
+        List<Tenant> tenants = tenantRepository.findAllBySubscriptionStatus(SubscriptionStatus.ACTIVE);
         for (Tenant tenant : tenants) {
             try {
                 logger.info("Processing reminders for tenant {}", tenant.getName());


### PR DESCRIPTION
## Summary
- query only active tenants when sending appointment reminders
- expose method in `TenantRepository` to filter by subscription status

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6854aa9a2e58832c8aa0d7a69982b857