### PR TITLE
Fix query for TimeSlot repository

### DIFF
--- a/src/main/java/com/myslotify/slotify/repository/TimeSlotRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/TimeSlotRepository.java
@@ -13,5 +13,5 @@ public interface TimeSlotRepository extends JpaRepository<TimeSlot, UUID> {
 
     java.util.List<TimeSlot> findAllByAppointmentAppointmentId(UUID appointmentId);
 
-    java.util.List<TimeSlot> findAllByAvailabilityEmployeeIdAndStatus(UUID employeeId, SlotStatus status);
+    java.util.List<TimeSlot> findAllByAvailabilityEmployeeEmployeeIdAndStatus(UUID employeeId, SlotStatus status);
 }

--- a/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
@@ -153,7 +153,7 @@ public class AvailabilityServiceImpl implements AvailabilityService {
         logger.info("Fetching available time slots for current employee");
         Employee employee = getCurrentEmployee(auth);
         return timeSlotRepository
-                .findAllByAvailabilityEmployeeIdAndStatus(employee.getEmployeeId(), SlotStatus.AVAILABLE);
+                .findAllByAvailabilityEmployeeEmployeeIdAndStatus(employee.getEmployeeId(), SlotStatus.AVAILABLE);
     }
 
     public List<TimeSlot> getAvailableTimeSlotsForEmployee(UUID employeeId) {
@@ -161,6 +161,6 @@ public class AvailabilityServiceImpl implements AvailabilityService {
             throw new NotFoundException("Employee not found");
         }
         return timeSlotRepository
-                .findAllByAvailabilityEmployeeIdAndStatus(employeeId, SlotStatus.AVAILABLE);
+                .findAllByAvailabilityEmployeeEmployeeIdAndStatus(employeeId, SlotStatus.AVAILABLE);
     }
 }


### PR DESCRIPTION
## Summary
- update `TimeSlotRepository` method to reference `employeeId`
- fix service layer calls after repository method rename

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68558ba49290832ca0cf73cf7b594032