### PR TITLE
Add database foreign key constraints

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-system.xml
+++ b/src/main/resources/db/changelog/db.changelog-system.xml
@@ -61,4 +61,13 @@
       </column>
     </createTable>
   </changeSet>
+  <changeSet id="add-tenant-admin-fk" author="nikola">
+    <addForeignKeyConstraint baseTableName="tenant"
+                             baseTableSchemaName="system"
+                             baseColumnNames="admin_id"
+                             referencedTableName="admin"
+                             referencedTableSchemaName="system"
+                             referencedColumnNames="admin_id"
+                             constraintName="fk_tenant_admin"/>
+  </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-tenant.xml
+++ b/src/main/resources/db/changelog/db.changelog-tenant.xml
@@ -110,5 +110,35 @@
         <constraints nullable="false"/>
       </column>
     </createTable>
+    <addForeignKeyConstraint baseTableName="employee_availability"
+                             baseColumnNames="user_id"
+                             referencedTableName="employee"
+                             referencedColumnNames="user_id"
+                             constraintName="fk_availability_employee"/>
+    <addForeignKeyConstraint baseTableName="time_slot"
+                             baseColumnNames="availability_id"
+                             referencedTableName="employee_availability"
+                             referencedColumnNames="availability_id"
+                             constraintName="fk_time_slot_availability"/>
+    <addForeignKeyConstraint baseTableName="time_slot"
+                             baseColumnNames="appointment_id"
+                             referencedTableName="appointment"
+                             referencedColumnNames="appointment_id"
+                             constraintName="fk_time_slot_appointment"/>
+    <addForeignKeyConstraint baseTableName="appointment"
+                             baseColumnNames="user_id"
+                             referencedTableName="employee"
+                             referencedColumnNames="user_id"
+                             constraintName="fk_appointment_employee"/>
+    <addForeignKeyConstraint baseTableName="appointment"
+                             baseColumnNames="customer_id"
+                             referencedTableName="user"
+                             referencedColumnNames="user_id"
+                             constraintName="fk_appointment_customer"/>
+    <addForeignKeyConstraint baseTableName="appointment"
+                             baseColumnNames="service_id"
+                             referencedTableName="service"
+                             referencedColumnNames="service_id"
+                             constraintName="fk_appointment_service"/>
   </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- add foreign key from tenant to admin in system changelog
- link appointment, availability, timeslot, service and employee tables with foreign keys

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855d41f409c832c8b8e99e3149a9488