### PR TITLE
Fix enum mapping for Tenant.subscriptionStatus

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/Tenant.java
+++ b/src/main/java/com/myslotify/slotify/entity/Tenant.java
@@ -21,6 +21,7 @@ public class Tenant {
     private String schemaName;
     @Column(name = "description", nullable = false)
     private String description;
+    @Enumerated(EnumType.STRING)
     @Column(name = "subscription_status", nullable = false)
     private SubscriptionStatus subscriptionStatus;
   


### PR DESCRIPTION
## Summary
- annotate `Tenant.subscriptionStatus` with `@Enumerated(EnumType.STRING)` so JPA matches the varchar column

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6855da06225c832cbd0cc95e527979ce