### PR TITLE
Fix foreign key constraints on Employee tables

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/Employee.java
+++ b/src/main/java/com/myslotify/slotify/entity/Employee.java
@@ -17,7 +17,7 @@ public class Employee {
     private UUID employeeId;
 
     @OneToOne
-    @JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false, unique = true)
     private User user;
 
     @OneToMany(mappedBy = "employee", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/resources/db/changelog/db.changelog-tenant.xml
+++ b/src/main/resources/db/changelog/db.changelog-tenant.xml
@@ -50,7 +50,7 @@
         <constraints primaryKey="true" nullable="false"/>
       </column>
       <column name="user_id" type="UUID">
-        <constraints nullable="false"/>
+        <constraints nullable="false" unique="true"/>
       </column>
     </createTable>
     <addForeignKeyConstraint baseTableName="employee"


### PR DESCRIPTION
## Summary
- make `employee.user_id` unique in tenant changelog
- mark user reference unique in `Employee` entity

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6855dbc62ec8832c930218553a393744