### PR TITLE
Handle tenant update without multipart files

### DIFF
--- a/src/main/java/com/myslotify/slotify/dto/TenantRequest.java
+++ b/src/main/java/com/myslotify/slotify/dto/TenantRequest.java
@@ -22,6 +22,18 @@ public class TenantRequest {
     private String borderColour;
     private String font;
 
+    /**
+     * Existing logo URL. Used when updating a tenant without uploading a
+     * new file.
+     */
+    private String logoUrl;
+
+    /**
+     * Existing cover picture URL. Used when updating a tenant without a
+     * new file upload.
+     */
+    private String coverPictureUrl;
+
     private MultipartFile logo;
     private MultipartFile coverPicture;
 }

--- a/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
@@ -89,10 +89,14 @@ public class TenantServiceImpl implements TenantService {
         if (request.getLogo() != null && !request.getLogo().isEmpty()) {
             String logoPath = fileStorageService.store(request.getLogo());
             tenant.setLogoUrl(logoPath);
+        } else if (request.getLogoUrl() != null) {
+            tenant.setLogoUrl(request.getLogoUrl());
         }
         if (request.getCoverPicture() != null && !request.getCoverPicture().isEmpty()) {
             String coverPath = fileStorageService.store(request.getCoverPicture());
             tenant.setCoverPictureUrl(coverPath);
+        } else if (request.getCoverPictureUrl() != null) {
+            tenant.setCoverPictureUrl(request.getCoverPictureUrl());
         }
         tenant.setTenantAdmin(admin);
         tenant.setCreatedAt(LocalDateTime.now());
@@ -190,10 +194,14 @@ public class TenantServiceImpl implements TenantService {
         if (request.getLogo() != null && !request.getLogo().isEmpty()) {
             String logoPath = fileStorageService.store(request.getLogo());
             tenant.setLogoUrl(logoPath);
+        } else if (request.getLogoUrl() != null) {
+            tenant.setLogoUrl(request.getLogoUrl());
         }
         if (request.getCoverPicture() != null && !request.getCoverPicture().isEmpty()) {
             String coverPath = fileStorageService.store(request.getCoverPicture());
             tenant.setCoverPictureUrl(coverPath);
+        } else if (request.getCoverPictureUrl() != null) {
+            tenant.setCoverPictureUrl(request.getCoverPictureUrl());
         }
 
         tenantRepository.save(tenant);


### PR DESCRIPTION
## Summary
- support existing image URLs in `TenantRequest`
- store provided URLs in `TenantServiceImpl` when no file is uploaded

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6855ec53b29c832ca69911b80bbb60dc