### PR TITLE
Fix user lookup join

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/User.java
+++ b/src/main/java/com/myslotify/slotify/entity/User.java
@@ -5,7 +5,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Entity
-@Table(name = "user")
+@Table(name = "\"user\"")
 @Data
 @EqualsAndHashCode(callSuper = true)
 @AttributeOverride(name = "id", column = @Column(name = "user_id"))

--- a/src/main/java/com/myslotify/slotify/repository/EmployeeRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/EmployeeRepository.java
@@ -2,6 +2,8 @@ package com.myslotify.slotify.repository;
 
 import com.myslotify.slotify.entity.Employee;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,5 +11,6 @@ import java.util.UUID;
 
 @Repository
 public interface EmployeeRepository extends JpaRepository<Employee, UUID> {
-    Optional<Employee> findByUserEmail(String email);
+    @Query(value = "SELECT e.* FROM employee e LEFT JOIN \"user\" u ON e.user_id = u.user_id WHERE u.email = :email", nativeQuery = true)
+    Optional<Employee> findByUserEmail(@Param("email") String email);
 }


### PR DESCRIPTION
## Summary
- revert unnecessary Liquibase rename
- quote the `user` table name in JPA mapping
- use a native query for looking up an employee by user email

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6855ec888114832cb4c48a6e2401def7