### PR TITLE
Update tenant update behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,5 +130,8 @@ Tenant admins can modify details about their tenant once activated:
 PUT /api/tenants/me
 ```
 
-The request body uses the same format as tenant creation and the updated
-tenant record is returned on success.
+This endpoint consumes `multipart/form-data`. Use form fields with the same
+names as tenant creation (`name`, `description`, etc.). New logo or cover
+pictures can be uploaded via the `logo` and `coverPicture` fields. When these
+files are omitted, the existing images will be kept. The updated tenant record
+is returned on success.

--- a/Slotify.postman_collection.json
+++ b/Slotify.postman_collection.json
@@ -240,7 +240,7 @@
             "header": [
               {
                 "key": "Content-Type",
-                "value": "application/json"
+                "value": "multipart/form-data"
               },
               {
                 "key": "Authorization",
@@ -263,8 +263,14 @@
               ]
             },
             "body": {
-              "mode": "raw",
-              "raw": "{}"
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "name",
+                  "value": "Updated Tenant Name",
+                  "type": "text"
+                }
+              ]
             }
           },
           "response": []

--- a/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/TenantServiceImpl.java
@@ -191,17 +191,15 @@ public class TenantServiceImpl implements TenantService {
         tenant.setBackgroundColour(request.getBackgroundColour());
         tenant.setBorderColour(request.getBorderColour());
         tenant.setFont(request.getFont());
+
         if (request.getLogo() != null && !request.getLogo().isEmpty()) {
             String logoPath = fileStorageService.store(request.getLogo());
             tenant.setLogoUrl(logoPath);
-        } else if (request.getLogoUrl() != null) {
-            tenant.setLogoUrl(request.getLogoUrl());
         }
+
         if (request.getCoverPicture() != null && !request.getCoverPicture().isEmpty()) {
             String coverPath = fileStorageService.store(request.getCoverPicture());
             tenant.setCoverPictureUrl(coverPath);
-        } else if (request.getCoverPictureUrl() != null) {
-            tenant.setCoverPictureUrl(request.getCoverPictureUrl());
         }
 
         tenantRepository.save(tenant);


### PR DESCRIPTION
## Summary
- keep existing logo/cover when no new file is uploaded
- document optional image uploads for updating a tenant
- simplify Postman example

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6855f7130bc8832cbb7ac029e46e2102