### PR TITLE
Enable numeric duration parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The filter stores the tenant in a thread-local context so repositories and servi
 
 A Postman collection is provided to exercise the API. Import `Slotify.postman_collection.json` into Postman and update the environment variables for your host, tenant, and auth token.
 
+Service creation requests can now specify durations using plain numbers instead of the enum names. For example `"duration": 30` maps to a 30 minute interval.
+
 ## API documentation
 
 The project uses springdoc-openapi to expose Swagger UI. Once the application is running, navigate to [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html) to explore available endpoints. The raw OpenAPI spec can be retrieved from [http://localhost:8080/v3/api-docs](http://localhost:8080/v3/api-docs).

--- a/Slotify.postman_collection.json
+++ b/Slotify.postman_collection.json
@@ -400,7 +400,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"name\": \"Consultation\",\n  \"duration\": \"MINUTES_30\",\n  \"description\": \"Initial consult\",\n  \"price\": 50\n}"
+              "raw": "{\n  \"name\": \"Consultation\",\n  \"duration\": 30,\n  \"description\": \"Initial consult\",\n  \"price\": 50\n}"
             }
           },
           "response": []

--- a/src/main/java/com/myslotify/slotify/entity/Interval.java
+++ b/src/main/java/com/myslotify/slotify/entity/Interval.java
@@ -1,5 +1,7 @@
 package com.myslotify.slotify.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
 @Getter
@@ -27,6 +29,21 @@ public enum Interval {
     // Constructor
     Interval(int minutes) {
         this.minutes = minutes;
+    }
+
+    @JsonValue
+    public int toValue() {
+        return minutes;
+    }
+
+    @JsonCreator
+    public static Interval fromMinutes(int minutes) {
+        for (Interval interval : values()) {
+            if (interval.minutes == minutes) {
+                return interval;
+            }
+        }
+        throw new IllegalArgumentException("Invalid interval: " + minutes);
     }
 
 }


### PR DESCRIPTION
## Summary
- allow services to be created using numeric durations
- update example in Postman collection
- document numeric durations in README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_685603180438832c882bb81852959cd5