### PR TITLE
Add date filter for employee slots

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/TimeSlotController.java
+++ b/src/main/java/com/myslotify/slotify/controller/TimeSlotController.java
@@ -2,6 +2,7 @@ package com.myslotify.slotify.controller;
 
 import com.myslotify.slotify.entity.TimeSlot;
 import com.myslotify.slotify.service.AvailabilityService;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.slf4j.Logger;
@@ -23,8 +24,10 @@ public class TimeSlotController {
     }
 
     @GetMapping("/{employeeId}")
-    public ResponseEntity<List<TimeSlot>> getAvailableSlotsForEmployee(@PathVariable UUID employeeId) {
-        logger.info("Fetching available slots for employee {}", employeeId);
-        return ResponseEntity.ok(availabilityService.getAvailableTimeSlotsForEmployee(employeeId));
+    public ResponseEntity<List<TimeSlot>> getAvailableSlotsForEmployee(
+            @PathVariable UUID employeeId,
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) java.time.LocalDate date) {
+        logger.info("Fetching available slots for employee {} on {}", employeeId, date);
+        return ResponseEntity.ok(availabilityService.getAvailableTimeSlotsForEmployee(employeeId, date));
     }
 }

--- a/src/main/java/com/myslotify/slotify/repository/TimeSlotRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/TimeSlotRepository.java
@@ -14,4 +14,7 @@ public interface TimeSlotRepository extends JpaRepository<TimeSlot, UUID> {
     java.util.List<TimeSlot> findAllByAppointmentAppointmentId(UUID appointmentId);
 
     java.util.List<TimeSlot> findAllByAvailabilityEmployeeEmployeeIdAndStatus(UUID employeeId, SlotStatus status);
+
+    java.util.List<TimeSlot> findAllByAvailabilityEmployeeEmployeeIdAndAvailabilityDateAndStatus(
+            UUID employeeId, java.time.LocalDate date, SlotStatus status);
 }

--- a/src/main/java/com/myslotify/slotify/service/AvailabilityService.java
+++ b/src/main/java/com/myslotify/slotify/service/AvailabilityService.java
@@ -19,4 +19,5 @@ public interface AvailabilityService {
     void unblockTimeSlot(UUID timeSlotId, Authentication auth);
     List<TimeSlot> getAvailableTimeSlotsForEmployee(Authentication auth);
     List<TimeSlot> getAvailableTimeSlotsForEmployee(UUID employeeId);
+    List<TimeSlot> getAvailableTimeSlotsForEmployee(UUID employeeId, java.time.LocalDate date);
 }

--- a/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AvailabilityServiceImpl.java
@@ -163,4 +163,13 @@ public class AvailabilityServiceImpl implements AvailabilityService {
         return timeSlotRepository
                 .findAllByAvailabilityEmployeeEmployeeIdAndStatus(employeeId, SlotStatus.AVAILABLE);
     }
+
+    public List<TimeSlot> getAvailableTimeSlotsForEmployee(UUID employeeId, java.time.LocalDate date) {
+        if (!employeeRepository.existsById(employeeId)) {
+            throw new NotFoundException("Employee not found");
+        }
+        return timeSlotRepository
+                .findAllByAvailabilityEmployeeEmployeeIdAndAvailabilityDateAndStatus(
+                        employeeId, date, SlotStatus.AVAILABLE);
+    }
 }


### PR DESCRIPTION
## Summary
- allow specifying a date when querying an employee's available slots
- add repository method and service logic for filtering by date

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68560ca04f08832c9840617437e89dde