### PR TITLE
Allow unauthenticated user sign up

### DIFF
--- a/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
+++ b/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -43,6 +44,7 @@ public class SecurityConfig {
                                 "/api/tenants/key/**",
                                 "/api/admins/tenant"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/user").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/myslotify/slotify/controller/UserController.java
+++ b/src/main/java/com/myslotify/slotify/controller/UserController.java
@@ -85,7 +85,7 @@ public class UserController {
         return ResponseEntity.ok(userService.getCurrentUser(auth));
     }
 
-    @PreAuthorize("hasRole('USER')")
+    @PreAuthorize("permitAll()")
     @PostMapping("/user")
     public ResponseEntity<AuthResponse> createUser(@RequestBody CreateUserRequest request) {
         logger.info("Creating user {}", request.getEmail());


### PR DESCRIPTION
## Summary
- allow `/api/user` POST requests without authentication
- permit `createUser` endpoint for everyone

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6867bb381610832c9e0b65f9bc159fce