### PR TITLE
Fix user role check for employees endpoint

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/UserController.java
+++ b/src/main/java/com/myslotify/slotify/controller/UserController.java
@@ -28,7 +28,7 @@ public class UserController {
         this.userService = userService;
     }
 
-    @PreAuthorize("hasRole('TENANT_ADMIN')")
+    @PreAuthorize("hasRole('TENANT_ADMIN') or hasRole('CUSTOMER')")
     @GetMapping("/employee")
     public ResponseEntity<List<Employee>> getAllEmployees() {
         logger.info("Fetching all employees");


### PR DESCRIPTION
## Summary
- allow TENANT_ADMIN and CUSTOMER roles to access `getAllEmployees`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6871563f2c10832cb301931b95883866