### PR TITLE
Inject TenantFilter before JWT filter

### DIFF
--- a/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
+++ b/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.myslotify.slotify.configuration;
 
 import com.myslotify.slotify.filter.JwtAuthFilter;
+import com.myslotify.slotify.filter.TenantFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -25,9 +26,11 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtAuthFilter jwtAuthFilter;
+    private final TenantFilter tenantFilter;
 
-    public SecurityConfig(JwtAuthFilter jwtAuthFilter) {
+    public SecurityConfig(JwtAuthFilter jwtAuthFilter, TenantFilter tenantFilter) {
         this.jwtAuthFilter = jwtAuthFilter;
+        this.tenantFilter = tenantFilter;
     }
 
     @Bean
@@ -48,6 +51,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(tenantFilter, JwtAuthFilter.class)
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }

--- a/src/main/java/com/myslotify/slotify/filter/TenantFilter.java
+++ b/src/main/java/com/myslotify/slotify/filter/TenantFilter.java
@@ -8,11 +8,14 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
 @Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class TenantFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;


### PR DESCRIPTION
## Summary
- inject `TenantFilter` into `SecurityConfig`
- register `TenantFilter` before `JwtAuthFilter`
- annotate `TenantFilter` to run with highest precedence

## Testing
- `./mvnw test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688241e4dce0832cbf9c111ca3b1ddc3