### PR TITLE
Fix filter order in SecurityConfig

### DIFF
--- a/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
+++ b/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
@@ -51,8 +51,8 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .addFilterBefore(tenantFilter, JwtAuthFilter.class)
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(tenantFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(jwtAuthFilter, TenantFilter.class)
                 .build();
     }
 


### PR DESCRIPTION
## Summary
- ensure custom filters are inserted in proper order

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68824a512eb8832c893dd0c9ffc128c0