### PR TITLE
fix: avoid user serialization in employee

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/Employee.java
+++ b/src/main/java/com/myslotify/slotify/entity/Employee.java
@@ -1,5 +1,6 @@
 package com.myslotify.slotify.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -16,6 +17,7 @@ public class Employee {
     @Column(name = "employee_id")
     private UUID employeeId;
 
+    @JsonIgnore
     @OneToOne
     @JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false, unique = true)
     private User user;


### PR DESCRIPTION
## Summary
- prevent serialization of employee user by adding `@JsonIgnore`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.myslotify:slotify-backend:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_6894bd65e22c832c8a8ef786ba65df69