### PR TITLE
Avoid serializing user in Employee entity

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/Employee.java
+++ b/src/main/java/com/myslotify/slotify/entity/Employee.java
@@ -3,6 +3,8 @@ package com.myslotify.slotify.entity;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Getter;
+import lombok.ToString;
 
 import java.util.List;
 import java.util.UUID;
@@ -17,8 +19,9 @@ public class Employee {
     @Column(name = "employee_id")
     private UUID employeeId;
 
-    @JsonIgnore
-    @OneToOne
+    @Getter(onMethod_ = @JsonIgnore)
+    @ToString.Exclude
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false, unique = true)
     private User user;
 


### PR DESCRIPTION
## Summary
- prevent serialization of Employee.user
- mark Employee.user relationship as LAZY and exclude from toString

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to missing dependency; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894c08d8898832c9857a7000112d908