### PR TITLE
fix recursion between employee and availability

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/EmployeeAvailability.java
+++ b/src/main/java/com/myslotify/slotify/entity/EmployeeAvailability.java
@@ -1,7 +1,10 @@
 package com.myslotify.slotify.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.Getter;
+import lombok.ToString;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,7 +19,9 @@ public class EmployeeAvailability {
     @Column(name = "availability_id")
     private UUID availabilityId;
 
-    @ManyToOne
+    @Getter(onMethod_ = @JsonIgnore)
+    @ToString.Exclude
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false)
     private Employee employee;
 


### PR DESCRIPTION
## Summary
- prevent recursion in EmployeeAvailability by ignoring back-reference to Employee

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6894c529de68832cbfe12add33ed8cf3