### PR TITLE
Avoid recursive serialization between TimeSlot and availability

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/TimeSlot.java
+++ b/src/main/java/com/myslotify/slotify/entity/TimeSlot.java
@@ -2,6 +2,8 @@ package com.myslotify.slotify.entity;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.ToString;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.time.LocalTime;
 import java.util.UUID;
@@ -25,6 +27,8 @@ public class TimeSlot {
     @Column(name = "status", nullable = false)
     private SlotStatus status;
 
+    @ToString.Exclude
+    @JsonIgnore
     @ManyToOne
     @JoinColumn(name = "availability_id", nullable = false)
     private EmployeeAvailability availability;


### PR DESCRIPTION
## Summary
- prevent infinite recursion when serializing TimeSlot and EmployeeAvailability by ignoring back reference

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.myslotify:slotify-backend:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894c830ae1c832cb679d3b55ec24b46