### PR TITLE
Handle Hibernate proxies when serializing employees

### DIFF
--- a/src/main/java/com/myslotify/slotify/entity/Employee.java
+++ b/src/main/java/com/myslotify/slotify/entity/Employee.java
@@ -1,6 +1,7 @@
 package com.myslotify.slotify.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import java.util.UUID;
 @Entity
 @Table(name = "employee")
 @Data
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Employee {
 
     @Id
@@ -21,12 +23,17 @@ public class Employee {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false, unique = true)
+    @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
     private User user;
 
     @OneToMany(mappedBy = "employee", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
+    @ToString.Exclude
     private List<EmployeeAvailability> availabilities;
 
     @OneToMany(mappedBy = "employee", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
+    @ToString.Exclude
     private List<Appointment> appointments;
 
     @Column(name = "role")

--- a/src/main/java/com/myslotify/slotify/entity/User.java
+++ b/src/main/java/com/myslotify/slotify/entity/User.java
@@ -1,5 +1,6 @@
 package com.myslotify.slotify.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -10,6 +11,7 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = true)
 @AttributeOverride(name = "id", column = @Column(name = "user_id"))
 @Inheritance(strategy = InheritanceType.JOINED)
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class User extends BaseAccount {
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## Summary
- add `@JsonIgnoreProperties` to Employee and User entities to ignore Hibernate proxy handlers
- hide lazily-loaded collections in Employee to avoid serialization issues

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1)*

------
https://chatgpt.com/codex/tasks/task_e_68a21fe12920832ca5104403b3eccc33