### PR TITLE
Fix access denied when fetching user by ID

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/UserController.java
+++ b/src/main/java/com/myslotify/slotify/controller/UserController.java
@@ -71,7 +71,7 @@ public class UserController {
         return ResponseEntity.ok(userService.getAllUsers());
     }
 
-    @PreAuthorize("hasRole('TENANT_ADMIN') or (hasRole('CUSTOMER') and #id == authentication.principal.id)")
+    @PreAuthorize("hasAnyRole('TENANT_ADMIN','ADMIN') or (hasRole('CUSTOMER') and #id == authentication.principal.id)")
     @GetMapping("/user/{id}")
     public ResponseEntity<User> getUser(@PathVariable UUID id) {
         logger.info("Fetching user {}", id);


### PR DESCRIPTION
## Summary
- allow ADMIN role to fetch users by ID
- remove AccessDeniedException handler now that proper authorization rules are in place

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a22287d868832c828ef5d49769b6b4