### PR TITLE
Fix broken PreAuthorize expressions for user retrieval

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/UserController.java
+++ b/src/main/java/com/myslotify/slotify/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
         return ResponseEntity.ok(userService.getAllEmployees());
     }
 
-    @PreAuthorize("hasRole('TENANT_ADMIN') or (hasRole('CUSTOMER') or (hasRole('EMPLOYEE') and #id == authentication.principal.id)")
+    @PreAuthorize("hasRole('TENANT_ADMIN') or hasRole('CUSTOMER') or (hasRole('EMPLOYEE') and #id == authentication.principal.id)")
     @GetMapping("/employee/{id}")
     public ResponseEntity<Employee> getEmployee(@PathVariable UUID id) {
         logger.info("Fetching employee {}", id);
@@ -71,7 +71,7 @@ public class UserController {
         return ResponseEntity.ok(userService.getAllUsers());
     }
 
-    @PreAuthorize("hasRole('TENANT_ADMIN') or (hasRole('CUSTOMER') or (hasRole('EMPLOYEE') and #id == authentication.principal.id)")
+    @PreAuthorize("hasRole('TENANT_ADMIN') or hasRole('CUSTOMER') or (hasRole('EMPLOYEE') and #id == authentication.principal.id)")
     @GetMapping("/user/{id}")
     public ResponseEntity<User> getUser(@PathVariable UUID id) {
         logger.info("Fetching user {}", id);


### PR DESCRIPTION
## Summary
- close missing parentheses in `@PreAuthorize` for employee and user endpoints
- allow employees to access their own record without errors

## Testing
- `mvn -q test` *(fails: Could not resolve parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a23a8cc42c832cb8ef2c42522f80cf