### PR TITLE
Serve uploaded files

### DIFF
--- a/src/main/java/com/myslotify/slotify/config/WebConfig.java
+++ b/src/main/java/com/myslotify/slotify/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.myslotify.slotify.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${file.upload-dir:uploads}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        Path uploadPath = Paths.get(uploadDir).toAbsolutePath().normalize();
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:" + uploadPath + "/");
+    }
+}

--- a/src/main/java/com/myslotify/slotify/service/FileStorageServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/FileStorageServiceImpl.java
@@ -45,6 +45,6 @@ public class FileStorageServiceImpl implements FileStorageService {
         } catch (IOException e) {
             throw new RuntimeException("Failed to store file", e);
         }
-        return target.toString();
+        return "/uploads/" + filename;
     }
 }


### PR DESCRIPTION
## Summary
- return relative path from FileStorageService
- expose upload directory via `/uploads` mapping

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a247a8d9c0832caa264b4a0b6011cf