### PR TITLE
Allow public access to uploaded files

### DIFF
--- a/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
+++ b/src/main/java/com/myslotify/slotify/configuration/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -47,7 +46,8 @@ public class SecurityConfig {
                                 "/api/tenants/key/**",
                                 "/api/admins/tenant",
                                 "/api/user",
-                                "/api/availability"
+                                "/api/availability",
+                                "/uploads/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## Summary
- allow unauthenticated clients to fetch files from `/uploads/**`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a249197a4c832c9bec6f7247bd9df9