### PR TITLE
Refactor appointments retrieval with auth

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/AppointmentController.java
+++ b/src/main/java/com/myslotify/slotify/controller/AppointmentController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -33,13 +33,13 @@ public class AppointmentController {
     }
 
     @GetMapping
-    public ResponseEntity<List<Appointment>> getAppointmentsBetween(
-            @RequestParam("start")
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
-            @RequestParam("end")
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime end) {
-        logger.info("Fetching appointments between {} and {}", start, end);
-        return ResponseEntity.ok(appointmentService.getAppointmentsBetween(start, end));
+    @PreAuthorize("hasAnyRole('CUSTOMER','EMPLOYEE')")
+    public ResponseEntity<List<Appointment>> getAppointments(
+            @RequestParam(value = "date", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            Authentication auth) {
+        logger.info("Fetching appointments for date {}", date);
+        return ResponseEntity.ok(appointmentService.getAppointments(date, auth));
     }
 
     @PostMapping

--- a/src/main/java/com/myslotify/slotify/repository/AppointmentRepository.java
+++ b/src/main/java/com/myslotify/slotify/repository/AppointmentRepository.java
@@ -10,7 +10,9 @@ import java.util.UUID;
 
 @Repository
 public interface AppointmentRepository extends JpaRepository<Appointment, UUID> {
-    List<Appointment> findByAppointmentTimeBetween(LocalDateTime start, LocalDateTime end);
+    List<Appointment> findByEmployeeEmployeeIdAndAppointmentTimeBetween(UUID employeeId, LocalDateTime start, LocalDateTime end);
+
+    List<Appointment> findByCustomerIdAndAppointmentTimeAfter(UUID customerId, LocalDateTime time);
 
     List<Appointment> findByAppointmentTimeBetweenAndReminderSentFalse(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/myslotify/slotify/service/AppointmentService.java
+++ b/src/main/java/com/myslotify/slotify/service/AppointmentService.java
@@ -3,13 +3,13 @@ package com.myslotify.slotify.service;
 import com.myslotify.slotify.entity.Appointment;
 import org.springframework.security.core.Authentication;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 public interface AppointmentService {
     Appointment getAppointment(UUID id);
-    List<Appointment> getAppointmentsBetween(LocalDateTime start, LocalDateTime end);
+    List<Appointment> getAppointments(LocalDate date, Authentication auth);
     void sendRemindersForUpcomingAppointments();
 
     Appointment createAppointment(UUID slotId, UUID serviceId, Authentication auth);

--- a/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AppointmentServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -53,9 +54,20 @@ public class AppointmentServiceImpl implements AppointmentService {
     }
 
     @Override
-    public List<Appointment> getAppointmentsBetween(LocalDateTime start, LocalDateTime end) {
-        logger.info("Fetching appointments between {} and {}", start, end);
-        return appointmentRepository.findByAppointmentTimeBetween(start, end);
+    public List<Appointment> getAppointments(LocalDate date, Authentication auth) {
+        if (date != null) {
+            Employee employee = getCurrentEmployee(auth);
+            LocalDateTime start = date.atStartOfDay();
+            LocalDateTime end = start.plusDays(1);
+            logger.info("Fetching appointments for employee {} on {}", employee.getEmployeeId(), date);
+            return appointmentRepository.findByEmployeeEmployeeIdAndAppointmentTimeBetween(
+                    employee.getEmployeeId(), start, end);
+        } else {
+            User user = getCurrentUser(auth);
+            LocalDateTime now = LocalDateTime.now();
+            logger.info("Fetching upcoming appointments for customer {}", user.getId());
+            return appointmentRepository.findByCustomerIdAndAppointmentTimeAfter(user.getId(), now);
+        }
     }
 
     private User getCurrentUser(Authentication auth) {


### PR DESCRIPTION
## Summary
- replace getAppointmentsBetween with getAppointments using optional date and authentication
- support employee day view and customer upcoming appointments
- add repository queries for employee and customer appointment lookups

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a39289da0c832c8e08031ccc430a2b