### PR TITLE
Use String for appointment request IDs

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/AppointmentController.java
+++ b/src/main/java/com/myslotify/slotify/controller/AppointmentController.java
@@ -45,23 +45,28 @@ public class AppointmentController {
     @PostMapping
     @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<Appointment> createAppointment(
-            @RequestParam UUID slotId,
-            @RequestParam UUID serviceId,
+            @RequestParam String slotId,
+            @RequestParam String serviceId,
             Authentication auth) {
         logger.info("Creating appointment for slot {} and service {}", slotId, serviceId);
-        return ResponseEntity.ok(appointmentService.createAppointment(slotId, serviceId, auth));
+        return ResponseEntity.ok(
+                appointmentService.createAppointment(UUID.fromString(slotId), UUID.fromString(serviceId), auth));
     }
 
     @PostMapping("/customer")
     @PreAuthorize("hasRole('EMPLOYEE')")
     public ResponseEntity<Appointment> createAppointmentForCustomer(
-            @RequestParam UUID slotId,
-            @RequestParam UUID serviceId,
-            @RequestParam UUID customerId,
+            @RequestParam String slotId,
+            @RequestParam String serviceId,
+            @RequestParam String customerId,
             Authentication auth) {
         logger.info("Employee creating appointment for customer {} on slot {} and service {}", customerId, slotId, serviceId);
         return ResponseEntity.ok(
-                appointmentService.createAppointmentForCustomer(slotId, serviceId, customerId, auth));
+                appointmentService.createAppointmentForCustomer(
+                        UUID.fromString(slotId),
+                        UUID.fromString(serviceId),
+                        UUID.fromString(customerId),
+                        auth));
     }
 
     @DeleteMapping("/{id}")


### PR DESCRIPTION
## Summary
- accept String parameters for slot, service, and customer IDs in `AppointmentController`
- convert String IDs to `UUID` before invoking service

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a39a0e738c832c9a19f56c856e143c