### PR TITLE
Use request bodies for appointment creation

### DIFF
--- a/Slotify.postman_collection.json
+++ b/Slotify.postman_collection.json
@@ -1181,6 +1181,10 @@
             "method": "POST",
             "header": [
               {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
                 "key": "Authorization",
                 "value": "Bearer {{token}}"
               },
@@ -1190,14 +1194,18 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/api/appointments?slotId={{slotId}}&serviceId={{serviceId}}",
+              "raw": "{{baseUrl}}/api/appointments",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
-                "appointments?slotId={{slotId}}&serviceId={{serviceId}}"
+                "appointments"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"slotId\":\"{{slotId}}\",\"serviceId\":\"{{serviceId}}\"}"
             }
           },
           "response": []
@@ -1208,6 +1216,10 @@
             "method": "POST",
             "header": [
               {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
                 "key": "Authorization",
                 "value": "Bearer {{token}}"
               },
@@ -1217,15 +1229,19 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/api/appointments/customer?slotId={{slotId}}&serviceId={{serviceId}}&customerId={{userId}}",
+              "raw": "{{baseUrl}}/api/appointments/customer",
               "host": [
                 "{{baseUrl}}"
               ],
               "path": [
                 "api",
                 "appointments",
-                "customer?slotId={{slotId}}&serviceId={{serviceId}}&customerId={{userId}}"
+                "customer"
               ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"slotId\":\"{{slotId}}\",\"serviceId\":\"{{serviceId}}\",\"customerId\":\"{{userId}}\"}"
             }
           },
           "response": []

--- a/src/main/java/com/myslotify/slotify/controller/AppointmentController.java
+++ b/src/main/java/com/myslotify/slotify/controller/AppointmentController.java
@@ -1,5 +1,7 @@
 package com.myslotify.slotify.controller;
 
+import com.myslotify.slotify.dto.CreateAppointmentForCustomerRequest;
+import com.myslotify.slotify.dto.CreateAppointmentRequest;
 import com.myslotify.slotify.entity.Appointment;
 import com.myslotify.slotify.service.AppointmentService;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -45,27 +47,24 @@ public class AppointmentController {
     @PostMapping
     @PreAuthorize("hasRole('CUSTOMER')")
     public ResponseEntity<Appointment> createAppointment(
-            @RequestParam String slotId,
-            @RequestParam String serviceId,
+            @RequestBody CreateAppointmentRequest request,
             Authentication auth) {
-        logger.info("Creating appointment for slot {} and service {}", slotId, serviceId);
+        logger.info("Creating appointment for slot {} and service {}", request.getSlotId(), request.getServiceId());
         return ResponseEntity.ok(
-                appointmentService.createAppointment(UUID.fromString(slotId), UUID.fromString(serviceId), auth));
+                appointmentService.createAppointment(request.getSlotId(), request.getServiceId(), auth));
     }
 
     @PostMapping("/customer")
     @PreAuthorize("hasRole('EMPLOYEE')")
     public ResponseEntity<Appointment> createAppointmentForCustomer(
-            @RequestParam String slotId,
-            @RequestParam String serviceId,
-            @RequestParam String customerId,
+            @RequestBody CreateAppointmentForCustomerRequest request,
             Authentication auth) {
-        logger.info("Employee creating appointment for customer {} on slot {} and service {}", customerId, slotId, serviceId);
+        logger.info("Employee creating appointment for customer {} on slot {} and service {}", request.getCustomerId(), request.getSlotId(), request.getServiceId());
         return ResponseEntity.ok(
                 appointmentService.createAppointmentForCustomer(
-                        UUID.fromString(slotId),
-                        UUID.fromString(serviceId),
-                        UUID.fromString(customerId),
+                        request.getSlotId(),
+                        request.getServiceId(),
+                        request.getCustomerId(),
                         auth));
     }
 

--- a/src/main/java/com/myslotify/slotify/dto/CreateAppointmentForCustomerRequest.java
+++ b/src/main/java/com/myslotify/slotify/dto/CreateAppointmentForCustomerRequest.java
@@ -1,0 +1,13 @@
+package com.myslotify.slotify.dto;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class CreateAppointmentForCustomerRequest {
+    private UUID slotId;
+    private UUID serviceId;
+    private UUID customerId;
+}
+

--- a/src/main/java/com/myslotify/slotify/dto/CreateAppointmentRequest.java
+++ b/src/main/java/com/myslotify/slotify/dto/CreateAppointmentRequest.java
@@ -1,0 +1,12 @@
+package com.myslotify.slotify.dto;
+
+import lombok.Data;
+
+import java.util.UUID;
+
+@Data
+public class CreateAppointmentRequest {
+    private UUID slotId;
+    private UUID serviceId;
+}
+


### PR DESCRIPTION
## Summary
- Accept appointment creation data as JSON, using UUID fields.
- Added DTOs to capture slot, service, and customer IDs.
- Updated Postman collection to send request bodies instead of query params.

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68a39ecf3180832ca699fd9a2c32dc23