### PR TITLE
Add admin management APIs

### DIFF
--- a/src/main/java/com/myslotify/slotify/controller/AdminController.java
+++ b/src/main/java/com/myslotify/slotify/controller/AdminController.java
@@ -2,14 +2,16 @@ package com.myslotify.slotify.controller;
 
 import com.myslotify.slotify.dto.AuthResponse;
 import com.myslotify.slotify.dto.CreateUserRequest;
+import com.myslotify.slotify.dto.UpdateAdminRequest;
+import com.myslotify.slotify.entity.Admin;
 import com.myslotify.slotify.service.AdminService;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/admins")
@@ -28,4 +30,19 @@ public class AdminController {
         logger.info("Creating tenant admin with email {}", request.getEmail());
         return ResponseEntity.ok(adminService.createTenantAdmin(request));
     }
+
+    @PreAuthorize("hasRole('ADMIN') or (hasRole('TENANT_ADMIN') and #id == authentication.principal.id)")
+    @GetMapping("/{id}")
+    public ResponseEntity<Admin> getAdmin(@PathVariable UUID id) {
+        logger.info("Fetching admin {}", id);
+        return ResponseEntity.ok(adminService.getAdmin(id));
+    }
+
+    @PreAuthorize("hasRole('ADMIN') or (hasRole('TENANT_ADMIN') and #id == authentication.principal.id)")
+    @PutMapping("/{id}")
+    public ResponseEntity<Admin> updateAdmin(@PathVariable UUID id, @RequestBody UpdateAdminRequest request) {
+        logger.info("Updating admin {}", id);
+        return ResponseEntity.ok(adminService.updateAdmin(id, request));
+    }
+
 }

--- a/src/main/java/com/myslotify/slotify/controller/AuthController.java
+++ b/src/main/java/com/myslotify/slotify/controller/AuthController.java
@@ -5,10 +5,7 @@ import com.myslotify.slotify.dto.LoginRequest;
 import com.myslotify.slotify.dto.ResetPasswordRequest;
 import com.myslotify.slotify.service.AuthService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,5 +31,11 @@ public class AuthController {
     public ResponseEntity<AuthResponse> resetPassword(@RequestBody ResetPasswordRequest request) {
         logger.info("Reset password for {}", request.getEmail());
         return ResponseEntity.ok(authService.resetPassword(request));
+    }
+
+    @PostMapping("/admin/reset-password")
+    public ResponseEntity<AuthResponse> resetAdminPassword(@RequestBody ResetPasswordRequest request) {
+        logger.info("Reset admin password for {}", request.getEmail());
+        return ResponseEntity.ok(authService.resetAdminPassword(request));
     }
 }

--- a/src/main/java/com/myslotify/slotify/dto/UpdateAdminRequest.java
+++ b/src/main/java/com/myslotify/slotify/dto/UpdateAdminRequest.java
@@ -1,0 +1,12 @@
+package com.myslotify.slotify.dto;
+
+import lombok.Data;
+
+@Data
+public class UpdateAdminRequest {
+    private String firstName;
+    private String lastName;
+    private String phone;
+    private String email;
+}
+

--- a/src/main/java/com/myslotify/slotify/service/AdminService.java
+++ b/src/main/java/com/myslotify/slotify/service/AdminService.java
@@ -2,9 +2,15 @@ package com.myslotify.slotify.service;
 
 import com.myslotify.slotify.dto.AuthResponse;
 import com.myslotify.slotify.dto.CreateUserRequest;
+import com.myslotify.slotify.dto.UpdateAdminRequest;
+import com.myslotify.slotify.entity.Admin;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 public interface AdminService {
     AuthResponse createTenantAdmin(CreateUserRequest request);
+    Admin getAdmin(UUID id);
+    Admin updateAdmin(UUID id, UpdateAdminRequest request);
 }

--- a/src/main/java/com/myslotify/slotify/service/AdminServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AdminServiceImpl.java
@@ -2,16 +2,20 @@ package com.myslotify.slotify.service;
 
 import com.myslotify.slotify.dto.AuthResponse;
 import com.myslotify.slotify.dto.CreateUserRequest;
+import com.myslotify.slotify.dto.UpdateAdminRequest;
 import com.myslotify.slotify.entity.Admin;
 import com.myslotify.slotify.entity.AdminRole;
 import com.myslotify.slotify.exception.BadRequestException;
+import com.myslotify.slotify.exception.NotFoundException;
 import com.myslotify.slotify.repository.AdminRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.myslotify.slotify.util.TenantContext;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Service
 public class AdminServiceImpl implements AdminService {
@@ -33,6 +37,7 @@ public class AdminServiceImpl implements AdminService {
     @Override
     public AuthResponse createTenantAdmin(CreateUserRequest request) {
         logger.info("Creating tenant admin with email {}", request.getEmail());
+        TenantContext.clear();
         Optional<Admin> existing = adminRepository.findByEmail(request.getEmail());
         if (existing.isPresent()) {
             throw new BadRequestException("Admin already exists");
@@ -52,4 +57,27 @@ public class AdminServiceImpl implements AdminService {
 
         return new AuthResponse("Admin registered successfully", token, admin, false);
     }
+
+    @Override
+    public Admin getAdmin(UUID id) {
+        logger.info("Fetching admin {}", id);
+        TenantContext.clear();
+        return adminRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Admin not found"));
+    }
+
+    @Override
+    public Admin updateAdmin(UUID id, UpdateAdminRequest request) {
+        logger.info("Updating admin {}", id);
+        TenantContext.clear();
+        Admin admin = adminRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Admin not found"));
+        admin.setFirstName(request.getFirstName());
+        admin.setLastName(request.getLastName());
+        admin.setEmail(request.getEmail());
+        admin.setPhone(request.getPhone());
+        adminRepository.save(admin);
+        return admin;
+    }
+
 }

--- a/src/main/java/com/myslotify/slotify/service/AuthService.java
+++ b/src/main/java/com/myslotify/slotify/service/AuthService.java
@@ -7,4 +7,5 @@ import com.myslotify.slotify.dto.ResetPasswordRequest;
 public interface AuthService {
     AuthResponse login(LoginRequest request);
     AuthResponse resetPassword(ResetPasswordRequest request);
+    AuthResponse resetAdminPassword(ResetPasswordRequest request);
 }

--- a/src/main/java/com/myslotify/slotify/service/AuthServiceImpl.java
+++ b/src/main/java/com/myslotify/slotify/service/AuthServiceImpl.java
@@ -119,4 +119,22 @@ public class AuthServiceImpl implements AuthService {
         String token = jwtService.generateToken(user);
         return new AuthResponse("Password reset successful", token, user, false);
     }
+
+    @Override
+    public AuthResponse resetAdminPassword(ResetPasswordRequest request) {
+        logger.info("Resetting password for admin {}", request.getEmail());
+        TenantContext.clear();
+        Admin admin = adminRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new NotFoundException("Admin not found"));
+
+        if (!passwordEncoder.matches(request.getTemporaryPassword(), admin.getPassword())) {
+            throw new UnauthorizedException("Temporary password is incorrect.");
+        }
+
+        admin.setPassword(passwordEncoder.encode(request.getNewPassword()));
+        adminRepository.save(admin);
+
+        String token = jwtService.generateToken(admin);
+        return new AuthResponse("Password reset successful", token, admin, false);
+    }
 }

--- a/src/test/java/com/myslotify/slotify/controller/AuthControllerTest.java
+++ b/src/test/java/com/myslotify/slotify/controller/AuthControllerTest.java
@@ -51,4 +51,15 @@ class AuthControllerTest {
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    void resetAdminPasswordEndpointReturnsOk() throws Exception {
+        ResetPasswordRequest request = new ResetPasswordRequest();
+        Mockito.when(authService.resetAdminPassword(Mockito.any())).thenReturn(new AuthResponse("ok", "token", null, false));
+
+        mockMvc.perform(post("/api/auth/admin/reset-password")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+    }
 }


### PR DESCRIPTION
## Summary
- add admin retrieval and profile update endpoints
- handle admin password changes via auth controller using `ResetPasswordRequest` and `AuthService`
- ensure admin service operations clear tenant context to run against default schema

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a793fe17d4832c81490087ca592880